### PR TITLE
Refactor ClassHUD into dedicated modules

### DIFF
--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -7,11 +7,10 @@ local LSM        = LibStub("LibSharedMedia-3.0")
 
 local ClassHUD   = AceAddon:NewAddon("ClassHUD", "AceEvent-3.0", "AceConsole-3.0")
 ClassHUD:SetDefaultModuleState(true)
+ClassHUD.ADDON_NAME = ADDON_NAME
 
 -- Global UI state for this addon (must exist before any function references it)
--- Must exist before any function references it
--- Global UI state
-local UI = {
+ClassHUD.UI = {
   anchor        = nil,
   cast          = nil,
   hp            = nil,
@@ -21,19 +20,11 @@ local UI = {
   runeBars      = {},
   icons         = nil,
   iconFrames    = {},
-  attachments   = {}, -- << NEW
+  attachments   = {},
 }
 
-
--- Class color (for HP)
-local function GetClassColor()
-  local _, class = UnitClass("player")
-  local c = RAID_CLASS_COLORS[class] or { r = 1, g = 1, b = 1 }
-  return c.r, c.g, c.b
-end
-
 -- Blizzard power colors
-local TOKEN_BY_ID = {
+ClassHUD.TOKEN_BY_ID = {
   [Enum.PowerType.Mana]          = "MANA",
   [Enum.PowerType.Rage]          = "RAGE",
   [Enum.PowerType.Focus]         = "FOCUS",
@@ -53,17 +44,6 @@ local TOKEN_BY_ID = {
   [Enum.PowerType.Essence]       = "ESSENCE",
 }
 
-local function PowerColorBy(id, token)
-  token = token or TOKEN_BY_ID[id]
-  local c = (token and PowerBarColor[token]) or PowerBarColor[id]
-  if c then return c.r, c.g, c.b end
-  return 0.2, 0.6, 1.0 -- sensible fallback
-end
-
-
--- ---------------------------------------------------------------------------
--- Defaults & DB
--- ---------------------------------------------------------------------------
 local defaults = {
   profile = {
     locked          = false,
@@ -80,20 +60,20 @@ local defaults = {
     show            = {
       cast     = true,
       hp       = true,
-      resource = true, -- primary (mana/rage/energy/etc., form/spec aware)
-      power    = true, -- special (CP/Chi/HolyPower/Shards/ArcaneCharges/Runes)
+      resource = true,
+      power    = true,
     },
 
     height          = {
       cast     = 18,
       hp       = 14,
       resource = 14,
-      power    = 14, -- per-segment height for runes/segments
+      power    = 14,
     },
 
     icons           = {
-      perRow = 8,  -- how many icons per row
-      spacing = 4, -- spacing in pixels
+      perRow = 8,
+      spacing = 4,
     },
 
     sideBars        = {
@@ -103,8 +83,8 @@ local defaults = {
     },
     topBar          = {
       perRow   = 8,
-      spacingX = 4, -- horizontal spacing between icons
-      spacingY = 4, -- vertical spacing between rows
+      spacingX = 4,
+      spacingY = 4,
       yOffset  = 0,
     },
     topBarSpells    = {},
@@ -113,609 +93,50 @@ local defaults = {
     bottomBarSpells = {},
     bottomBar       = {
       perRow   = 8,
-      spacingX = 4, -- horizontal spacing
-      spacingY = 4, -- vertical spacing
+      spacingX = 4,
+      spacingY = 4,
       yOffset  = 0,
     },
 
-
     colors = {
       hp = { r = 0.10, g = 0.80, b = 0.10 },
-      resourceClass = true,                     -- use class color for primary resource
+      resourceClass = true,
       resource = { r = 0.00, g = 0.55, b = 1.00 },
-      power = { r = 1.00, g = 0.85, b = 0.10 }, -- fallback for special segments
+      power = { r = 1.00, g = 0.85, b = 0.10 },
     },
   }
 }
 
+ClassHUD.defaults = defaults
 
+function ClassHUD:GetClassColor()
+  local _, class = UnitClass("player")
+  local c = RAID_CLASS_COLORS[class] or { r = 1, g = 1, b = 1 }
+  return c.r, c.g, c.b
+end
 
+function ClassHUD:PowerColorBy(id, token)
+  token = token or self.TOKEN_BY_ID[id]
+  local c = (token and PowerBarColor[token]) or PowerBarColor[id]
+  if c then return c.r, c.g, c.b end
+  return 0.2, 0.6, 1.0
+end
 
--- Handy
-local function FetchStatusbar()
-  return LSM:Fetch("statusbar", ClassHUD.db.profile.textures.bar)
+function ClassHUD:FetchStatusbar()
+  return LSM:Fetch("statusbar", self.db.profile.textures.bar)
       or "Interface\\TargetingFrame\\UI-StatusBar"
 end
 
-local function FetchFont(size, flags)
-  local path = LSM:Fetch("font", ClassHUD.db.profile.textures.font) or STANDARD_TEXT_FONT
+function ClassHUD:FetchFont(size, flags)
+  local path = LSM:Fetch("font", self.db.profile.textures.font) or STANDARD_TEXT_FONT
   return path, size, flags or "OUTLINE"
 end
 
--- ---------------------------------------------------------------------------
--- Primary/Secondary power picking (form/spec aware)
--- ---------------------------------------------------------------------------
-
--- Special segmented power (or runes). Returns a table descriptor or nil.
--- ---------------------------------------------------------------------------
--- Frames
--- ---------------------------------------------------------------------------
-
-function ClassHUD:ApplyAnchorPosition()
-  if not UI.anchor then return end
-  local pos = self.db.profile.position or { x = 0, y = -350 }
-  UI.anchor:ClearAllPoints()
-  UI.anchor:SetPoint("CENTER", UIParent, "CENTER", pos.x or 0, pos.y or 0)
-end
-
-local function CreateAnchor()
-  local f = CreateFrame("Frame", "ClassHUDAnchor", UIParent, "BackdropTemplate")
-  f:SetSize(250, 1)
-  f:SetMovable(false) -- no drag; we control via offsets
-  UI.anchor = f
-end
-
-local function CreateStatusBar(parent, height)
-  local bar = CreateFrame("StatusBar", nil, parent, "BackdropTemplate")
-  bar:SetStatusBarTexture(FetchStatusbar())
-  bar:SetMinMaxValues(0, 1)
-  bar:SetValue(0)
-  bar.bg = bar:CreateTexture(nil, "BACKGROUND")
-  bar.bg:SetAllPoints(true)
-  bar.bg:SetColorTexture(0, 0, 0, 0.55)
-
-  bar.text = bar:CreateFontString(nil, "OVERLAY")
-  bar.text:SetPoint("CENTER")
-  bar.text:SetFont(FetchFont(12))
-
-  bar:SetHeight(height)
-  bar:SetWidth(250)
-  return bar
-end
-
-local function CreateCastBar()
-  local h = ClassHUD.db.profile.height.cast
-  local b = CreateStatusBar(UI.anchor, h)
-
-  b.icon = b:CreateTexture(nil, "ARTWORK")
-  b.icon:SetSize(h, h)
-  b.icon:SetPoint("LEFT", b, "LEFT", 0, 0)
-  b.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
-
-  b.spell = b:CreateFontString(nil, "OVERLAY")
-  b.spell:SetFont(FetchFont(12))
-  b.spell:SetPoint("LEFT", b.icon, "RIGHT", 4, 0)
-  b.spell:SetJustifyH("LEFT")
-
-  b.time = b:CreateFontString(nil, "OVERLAY")
-  b.time:SetFont(FetchFont(12))
-  b.time:SetPoint("RIGHT", b, "RIGHT", -3, 0)
-  b.time:SetJustifyH("RIGHT")
-
-  b:SetStatusBarColor(1, .7, 0)
-  b:Hide()
-  UI.cast = b
-end
-
-local function CreateHPBar()
-  local b = CreateStatusBar(UI.anchor, ClassHUD.db.profile.height.hp)
-  local r, g, bCol = GetClassColor()
-  b:SetStatusBarColor(r, g, bCol)
-  UI.hp = b
-end
-
-
-local function CreateResourceBar()
-  local b = CreateStatusBar(UI.anchor, ClassHUD.db.profile.height.resource)
-  if ClassHUD.db.profile.colors.resourceClass then
-    b:SetStatusBarColor(GetClassColor())
-  else
-    local c = ClassHUD.db.profile.colors.resource
-    b:SetStatusBarColor(c.r, c.g, c.b)
-  end
-  UI.resource = b
-end
-
-local function CreatePowerContainer()
-  local f = CreateFrame("Frame", nil, UI.anchor, "BackdropTemplate")
-  f:SetSize(250, 16)
-  UI.power = f
-end
-
--- ---------------------------------------------------------------------------
--- Layout (top→bottom): cast → hp → resource → power
--- ---------------------------------------------------------------------------
-local function ApplyBarSkins()
-  local tex = FetchStatusbar()
-  for _, sb in pairs({ UI.cast, UI.hp, UI.resource }) do
-    if sb and sb.SetStatusBarTexture then
-      sb:SetStatusBarTexture(tex)
-    end
-  end
-  if UI.cast then
-    UI.cast.spell:SetFont(FetchFont(12))
-    UI.cast.time:SetFont(FetchFont(12))
-  end
-  if UI.hp then UI.hp.text:SetFont(FetchFont(12)) end
-  if UI.resource then UI.resource.text:SetFont(FetchFont(12)) end
-end
-
-local function Layout()
-  local w   = ClassHUD.db.profile.width
-  local gap = ClassHUD.db.profile.spacing
-
-  UI.anchor:SetWidth(w)
-
-  local y = 0
-
-  -- Cast (top)
-  if ClassHUD.db.profile.show.cast then
-    UI.cast:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
-    UI.cast:SetWidth(w)
-    UI.cast:SetHeight(ClassHUD.db.profile.height.cast)
-    y = y + UI.cast:GetHeight() + gap
-  else
-    UI.cast:ClearAllPoints(); UI.cast:Hide()
-  end
-
-  -- HP
-  if ClassHUD.db.profile.show.hp then
-    UI.hp:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
-    UI.hp:SetWidth(w)
-    UI.hp:SetHeight(ClassHUD.db.profile.height.hp)
-    y = y + UI.hp:GetHeight() + gap
-  else
-    UI.hp:ClearAllPoints(); UI.hp:Hide()
-  end
-
-  -- Primary resource
-  if ClassHUD.db.profile.show.resource then
-    UI.resource:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
-    UI.resource:SetWidth(w)
-    UI.resource:SetHeight(ClassHUD.db.profile.height.resource)
-    y = y + UI.resource:GetHeight() + gap
-  else
-    UI.resource:ClearAllPoints(); UI.resource:Hide()
-  end
-
-  -- Special power container
-  if ClassHUD.db.profile.show.power then
-    UI.power:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
-    UI.power:SetWidth(w)
-    UI.power:SetHeight(ClassHUD.db.profile.height.power)
-  else
-    UI.power:ClearAllPoints(); UI.power:Hide()
-  end
-
-  -- Update attachment points
-  local function ensure(name)
-    if not UI.attachments[name] then
-      UI.attachments[name] = CreateFrame("Frame", "ClassHUDAttach" .. name, UI.anchor)
-      UI.attachments[name]:SetSize(1, 1)
-    end
-    return UI.attachments[name]
-  end
-
-  -- Top (above castbar, shifted by castbar height)
-  -- Top (a 1px-tall strip directly above the cast bar, stretched to its width)
-  local top = ensure("TOP")
-  top:ClearAllPoints()
-  top:SetPoint("BOTTOMLEFT", UI.cast, "TOPLEFT", 0, 0)
-  top:SetPoint("BOTTOMRIGHT", UI.cast, "TOPRIGHT", 0, 0)
-  top:SetHeight(1)
-
-
-  -- Bottom (a 1px-tall strip directly below the power bar, stretched to its width)
-  local bottom = ensure("BOTTOM")
-  bottom:ClearAllPoints()
-  bottom:SetPoint("TOPLEFT", UI.power, "BOTTOMLEFT", 0, 0)
-  bottom:SetPoint("TOPRIGHT", UI.power, "BOTTOMRIGHT", 0, 0)
-  bottom:SetHeight(1)
-
-
-  -- Left
-  local left = ensure("LEFT")
-  left:ClearAllPoints()
-  left:SetPoint("RIGHT", UI.anchor, "LEFT", -4, 0)
-
-  -- Right
-  local right = ensure("RIGHT")
-  right:ClearAllPoints()
-  right:SetPoint("LEFT", UI.anchor, "RIGHT", 4, 0)
-
-
-  ApplyBarSkins()
-end
-
--- ---------------------------------------------------------------------------
--- Updates
--- ---------------------------------------------------------------------------
-local function StopCast()
-  -- Don’t stop if player is still casting or channeling something
-  local casting = UnitCastingInfo("player")
-  local channeling = UnitChannelInfo("player")
-  if casting or channeling then
-    return
-  end
-
-  if UI.cast then
-    UI.cast:SetScript("OnUpdate", nil)
-    UI.cast:Hide()
-    UI.cast:SetValue(0)
-    UI.cast.time:SetText("")
-    UI.cast.spell:SetText("")
-    UI.cast.icon:SetTexture(nil)
-  end
-end
-
-
-local function StartCast(name, icon, startMS, endMS)
-  if not ClassHUD.db.profile.show.cast then return end
-  local total = (endMS - startMS) / 1000
-  local start = startMS / 1000
-
-  UI.cast:Show()
-  UI.cast.spell:SetText(name or "")
-  UI.cast.icon:SetTexture(icon or 136243) -- generic
-  UI.cast:SetStatusBarColor(1, .7, 0)
-
-  UI.cast:SetScript("OnUpdate", function(self)
-    local now = GetTime()
-    local elapsed = now - start
-    self:SetMinMaxValues(0, total)
-    self:SetValue(elapsed)
-    self.time:SetFormattedText("%.1f / %.1f", math.max(0, elapsed), total)
-
-    if elapsed >= total then
-      self:SetScript("OnUpdate", nil)
-      self:Hide()
-    end
-  end)
-end
-
-
-function ClassHUD:UNIT_SPELLCAST_START(_, unit)
-  if unit ~= "player" then return end
-  local name, _, icon, startMS, endMS = UnitCastingInfo("player")
-  if name then
-    StartCast(name, icon, startMS, endMS)
-  end
-end
-
-function ClassHUD:UNIT_SPELLCAST_CHANNEL_START(_, unit)
-  if unit ~= "player" then return end
-  local name, _, icon, startMS, endMS = UnitChannelInfo("player")
-  if name then
-    StartCast(name, icon, startMS, endMS)
-  end
-end
-
-function ClassHUD:UNIT_SPELLCAST_SUCCEEDED(_, unit, spellID)
-  if unit ~= "player" then return end
-  local name, _, icon = C_Spell.GetSpellInfo(spellID)
-  -- Only show if the spell is instant (no cast/channel active)
-  if name and not UnitCastingInfo("player") and not UnitChannelInfo("player") then
-    StartCast(name, icon, GetTime() * 1000, (GetTime() + 1) * 1000) -- show 1s fake bar
-  end
-end
-
-function ClassHUD:UNIT_SPELLCAST_STOP(_, unit)
-  if unit == "player" then StopCast() end
-end
-
-function ClassHUD:UNIT_SPELLCAST_CHANNEL_STOP(_, unit)
-  if unit == "player" then StopCast() end
-end
-
-function ClassHUD:UNIT_SPELLCAST_INTERRUPTED(_, unit)
-  if unit == "player" then StopCast() end
-end
-
-function ClassHUD:UNIT_SPELLCAST_FAILED(_, unit)
-  if unit == "player" then StopCast() end
-end
-
-local function UpdateHP()
-  if not ClassHUD.db.profile.show.hp then return end
-  local cur, max = UnitHealth("player"), UnitHealthMax("player")
-  UI.hp:SetMinMaxValues(0, max)
-  UI.hp:SetValue(cur)
-  local pct = (max > 0) and (cur / max * 100) or 0
-  UI.hp.text:SetFormattedText("%d%%", pct + 0.5)
-end
-
-local function UpdatePrimaryResource()
-  if not ClassHUD.db.profile.show.resource then return end
-
-  local id, token = UnitPowerType("player")
-  local cur, max = UnitPower("player", id), UnitPowerMax("player", id)
-  UI.resource:SetMinMaxValues(0, max > 0 and max or 1)
-  UI.resource:SetValue(cur)
-
-  -- color straight from Blizzard’s table
-  local r, g, b = PowerColorBy(id, token)
-  UI.resource:SetStatusBarColor(r, g, b)
-
-  if id == Enum.PowerType.Mana then
-    local pct = (max > 0) and (cur / max * 100) or 0
-    UI.resource.text:SetFormattedText("%d%%", pct + 0.5)
-  else
-    UI.resource.text:SetText(cur)
-  end
-end
-
-
-local function EnsureSegment(i)
-  if not UI.powerSegments[i] then
-    local sb = CreateStatusBar(UI.power, 16)
-    sb.text:Hide() -- segments don’t need text
-    UI.powerSegments[i] = sb
-  end
-  return UI.powerSegments[i]
-end
-
-local function HideAllSegments(from)
-  for i = from, #UI.powerSegments do
-    if UI.powerSegments[i] then UI.powerSegments[i]:Hide() end
-  end
-end
-
-
--- ========= Advanced Class Resource System =========
-
--- Map classes → special resource power types
-local CLASS_POWER_ID = {
-  MONK        = Enum.PowerType.Chi,
-  PALADIN     = Enum.PowerType.HolyPower,
-  WARLOCK     = Enum.PowerType.SoulShards,
-  ROGUE       = Enum.PowerType.ComboPoints,
-  DRUID       = Enum.PowerType.ComboPoints,   -- (cat form only)
-  MAGE        = Enum.PowerType.ArcaneCharges, -- (Arcane only)
-  EVOKER      = Enum.PowerType.Essence,
-  DEATHKNIGHT = Enum.PowerType.Runes,
-}
-
--- Specs that “unlock” the resource
-local REQUIRED_SPEC = {
-  MONK = 269, -- Windwalker
-  MAGE = 62,  -- Arcane
-}
-
--- Specs that use partial resource (e.g., Destruction shards)
-local USES_PARTIAL_BY_SPEC = {
-  [267] = true, -- Warlock Destruction
-}
-
--- Charged Combo Points highlight color (Rogue)
-local CHARGED_CP_COLOR = { 1.0, 0.95, 0.35 }
-
--- Base resource colors
-local RESOURCE_BASE_COLORS = {
-  [Enum.PowerType.HolyPower]     = { 1.00, 0.88, 0.25 },
-  [Enum.PowerType.SoulShards]    = { 0.60, 0.22, 1.00 },
-  [Enum.PowerType.ArcaneCharges] = { 0.25, 0.60, 1.00 },
-  [Enum.PowerType.Essence]       = { 0.50, 1.00, 0.90 },
-}
-
--- DK rune colors by spec
-local function RuneSpecColor(specID)
-  if specID == 250 then return 0.75, 0.10, 0.10 end -- Blood
-  if specID == 251 then return 0.35, 0.70, 1.00 end -- Frost
-  if specID == 252 then return 0.20, 0.95, 0.35 end -- Unholy
-  return 0.7, 0.7, 0.7
-end
-
--- Per-index color for CP/Chi/Arcane
-local function IndexedColor(i, max)
-  if max <= 1 then return 1, 1, 1 end
-  local t = (i - 1) / (max - 1)
-  local r = 1.0
-  local g = math.min(1, 0.1 + 0.9 * t)
-  local b = math.max(0, 0.05 + 0.25 * (1 - t))
-  return r, g, b
-end
-
--- Get charged CP indices (Rogue)
-local function GetChargedPoints()
-  if not GetUnitChargedPowerPoints then return nil end
-  return GetUnitChargedPowerPoints("player")
-end
-
-local function SegmentColor(i, max, ptype, class, specID, chargedPoints)
-  if ptype == Enum.PowerType.Runes then
-    return RuneSpecColor(specID)
-  end
-  if ptype == Enum.PowerType.ComboPoints or ptype == Enum.PowerType.Chi or ptype == Enum.PowerType.ArcaneCharges then
-    if ptype == Enum.PowerType.ComboPoints and chargedPoints then
-      for _, idx in ipairs(chargedPoints) do
-        if idx == i then return unpack(CHARGED_CP_COLOR) end
-      end
-    end
-    return IndexedColor(i, max)
-  end
-  local base = RESOURCE_BASE_COLORS[ptype]
-  if base then return unpack(base) end
-  return PowerColorBy(ptype)
-end
-
--- Advanced segment updater
-local function UpdateSegmentsAdvanced(ptype, max, partial)
-  local w = ClassHUD.db.profile.width
-  local gap = ClassHUD.db.profile.powerSpacing or 1
-  local segW = (w - gap * (max - 1)) / max
-
-  local _, class = UnitClass("player")
-  local spec = GetSpecialization()
-  local specID = spec and GetSpecializationInfo(spec) or 0
-  local charged = (ptype == Enum.PowerType.ComboPoints and class == "ROGUE") and GetChargedPoints() or nil
-  local cur = UnitPower("player", ptype, partial and true or false)
-
-  local whole, frac = 0, 0
-  if partial then
-    local mod   = UnitPowerDisplayMod(ptype) or 1
-    local exact = cur / mod
-    whole       = math.floor(exact)
-    frac        = exact - whole
-  end
-
-  for i = 1, max do
-    local sb = EnsureSegment(i)
-    sb:SetStatusBarTexture(FetchStatusbar())
-    sb:SetSize(segW, ClassHUD.db.profile.height.power)
-    sb:ClearAllPoints()
-    if i == 1 then
-      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
-    else
-      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
-    end
-    local r, g, b = SegmentColor(i, max, ptype, class, specID, charged)
-    sb:SetStatusBarColor(r, g, b)
-    sb:SetMinMaxValues(0, 1)
-    sb:Show()
-
-    if partial then
-      if i <= whole then
-        sb:SetValue(1)
-      elseif i == whole + 1 then
-        sb:SetValue(frac)
-      else
-        sb:SetValue(0)
-      end
-    else
-      sb:SetValue(cur >= i and 1 or 0)
-    end
-  end
-  HideAllSegments(max + 1)
-end
-
--- Essence updater
-local function UpdateEssenceSegments(ptype)
-  local max = UnitPowerMax("player", ptype)
-  if not max or max <= 0 then
-    HideAllSegments(1); UI.power:Hide(); return
-  end
-  local w = ClassHUD.db.profile.width
-  local gap = ClassHUD.db.profile.powerSpacing or 1
-  local segW = (w - gap * (max - 1)) / max
-  local cur = UnitPower("player", ptype)
-  local partial = UnitPartialPower and (UnitPartialPower("player", ptype) or 0) or 0
-  local nextFrac = partial / 1000.0
-  local base = RESOURCE_BASE_COLORS[ptype] or { 0.5, 1, 0.9 }
-  local r, g, b = base[1], base[2], base[3]
-  for i = 1, max do
-    local sb = EnsureSegment(i)
-    sb:SetStatusBarTexture(FetchStatusbar())
-    sb:SetSize(segW, ClassHUD.db.profile.height.power)
-    sb:ClearAllPoints()
-    if i == 1 then
-      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
-    else
-      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
-    end
-    sb:SetMinMaxValues(0, 1)
-    sb:SetStatusBarColor(r, g, b)
-    sb:Show()
-    if i <= cur then
-      sb:SetValue(1)
-    elseif i == cur + 1 and cur < max then
-      sb:SetValue(nextFrac)
-    else
-      sb:SetValue(0)
-    end
-  end
-  HideAllSegments(max + 1)
-end
-
--- Resolve which special power to show
-local function ResolveSpecialPower()
-  local _, class = UnitClass("player")
-  local spec = GetSpecialization()
-  local specID = spec and GetSpecializationInfo(spec) or 0
-  local ptype = CLASS_POWER_ID[class]
-  if REQUIRED_SPEC[class] and specID ~= REQUIRED_SPEC[class] then return nil end
-  if class == "DRUID" and select(1, UnitPowerType("player")) ~= Enum.PowerType.Energy then
-    return nil
-  end
-  return ptype, specID
-end
-
--- Main update entry
-local function UpdateSpecialPower()
-  if not ClassHUD.db.profile.show.power then return end
-  local ptype, specID = ResolveSpecialPower()
-  if not ptype then
-    HideAllSegments(1); UI.power:Hide(); return
-  end
-  UI.power:Show()
-  if ptype == Enum.PowerType.Runes then
-    UpdateRunes()
-    return
-  elseif ptype == Enum.PowerType.Essence then
-    UpdateEssenceSegments(ptype)
-    return
-  end
-  local max = UnitPowerMax("player", ptype) or 0
-  local usePartial = USES_PARTIAL_BY_SPEC[specID] or false
-  UpdateSegmentsAdvanced(ptype, max, usePartial)
-end
-
-
-local function UpdateRunes()
-  -- 6 runes; each rune shows its cooldown fill
-  local w = 250
-  local spec = GetSpecialization()
-  local specID = spec and GetSpecializationInfo(spec) or 0
-  local rr, rg, rb = RuneSpecColor and RuneSpecColor(specID) or 0.7, 0.7, 0.7
-  local gap = 2
-  local max = 6
-  local segW = (w - gap * (max - 1)) / max
-  for i = 1, max do
-    local sb = EnsureSegment(i)
-    sb:SetStatusBarTexture(FetchStatusbar())
-    sb:SetSize(segW, 16)
-    sb:ClearAllPoints()
-    if i == 1 then
-      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
-    else
-      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
-    end
-    local start, duration, ready = GetRuneCooldown(i)
-    sb:SetMinMaxValues(0, 1)
-    if ready then
-      sb:SetValue(1); sb:SetStatusBarColor(rr, rg, rb)
-    elseif start and duration and duration > 0 then
-      local elapsed = GetTime() - start
-      sb:SetValue(math.min(elapsed / duration, 1))
-      sb:SetStatusBarColor(rr * 0.5, rg * 0.5, rb * 0.5)
-    else
-      sb:SetValue(1); sb:SetStatusBarColor(rr, rg, rb)
-    end
-    sb:Show()
-  end
-  HideAllSegments(max + 1)
-end
-
-
-
-
--- ---------------------------------------------------------------------------
--- Events wiring
--- ---------------------------------------------------------------------------
 function ClassHUD:FullUpdate()
-  Layout()
-  UpdateHP()
-  UpdatePrimaryResource()
-  UpdateSpecialPower()
+  self:LayoutBars()
+  self:UpdateHP()
+  self:UpdatePrimaryResource()
+  self:UpdateSpecialPower()
 end
 
 function ClassHUD:OnInitialize()
@@ -749,8 +170,7 @@ function ClassHUD:RegisterOptions()
     if not self._opts_missing_warned then
       self._opts_missing_warned = true
       print("|cff00ff88ClassHUD|r: ClassHUD_BuildOptions is missing. Using fallback options panel.")
-      print(
-        "|cff00ff88ClassHUD|r: Make sure ClassHUD_Options.lua is in the TOC, loads, and defines *global* function ClassHUD_BuildOptions(addon).")
+      print("|cff00ff88ClassHUD|r: Make sure ClassHUD_Options.lua is in the TOC, loads, and defines *global* function ClassHUD_BuildOptions(addon).")
     end
     opts = {
       type = "group",
@@ -759,8 +179,7 @@ function ClassHUD:RegisterOptions()
         note = {
           type = "description",
           order = 1,
-          name =
-          "Options file not loaded.\nCheck TOC path/name and that ClassHUD_Options.lua defines:\n\nfunction ClassHUD_BuildOptions(addon) ... return opts end\n"
+          name = "Options file not loaded.\nCheck TOC path/name and that ClassHUD_Options.lua defines:\n\nfunction ClassHUD_BuildOptions(addon) ... return opts end\n",
         },
       },
     }
@@ -789,373 +208,16 @@ function ClassHUD:OpenOptions()
   ACD:Open("ClassHUD")
 end
 
--- ===================================
--- Spell Tracking Module for ClassHUD
--- ===================================
-
--- Module
-local activeFrames = {}
-
--- Helpers (same as before)
-local function GetSpellIcon(spellID)
-  local info = C_Spell.GetSpellInfo(spellID)
-  return info and info.iconID or 134400
-end
-
-local function FormatSeconds(s)
-  if s >= 60 then
-    return string.format("%dm", math.ceil(s / 60))
-  elseif s >= 10 then
-    return tostring(math.floor(s + 0.5))
-  else
-    return string.format("%.1f", s)
-  end
-end
-
-local function CreateSpellFrame(data, index)
-  local frame = CreateFrame("Frame", ADDON_NAME .. "Spell" .. index, UIParent)
-
-  -- Default size (will be resized by layout)
-  frame:SetSize(40, 40)
-
-  -- Anchor placeholder (layout will override)
-  frame:SetPoint("CENTER", UIParent, "CENTER")
-
-  -- === ICON ===
-  frame.icon = frame:CreateTexture(nil, "ARTWORK")
-  frame.icon:SetAllPoints(frame)
-
-  -- === STACK COUNT (aura stacks) ===
-  frame.count = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
-  frame.count:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -2, 2)
-  frame.count:SetFont(GameFontNormalLarge:GetFont(), 14, "OUTLINE")
-  frame.count:SetDrawLayer("OVERLAY", 7)
-  frame.count:Hide()
-
-  -- === COOLDOWN SPIRAL ===
-  frame.cooldown = CreateFrame("Cooldown", nil, frame, "CooldownFrameTemplate")
-  frame.cooldown:SetAllPoints(frame)
-  frame.cooldown:SetHideCountdownNumbers(true) -- hide Blizzard numbers
-  frame.cooldown.noCooldownCount = true        -- prevent OmniCC from adding numbers
-  frame.cooldown:SetDrawEdge(false)
-
-  -- Raise spiral just above base, texts even higher
-  local lvl = frame:GetFrameLevel()
-  frame.cooldown:SetFrameLevel(lvl + 1)
-
-  -- === COOLDOWN TEXT (centered numeric countdown) ===
-  frame.cooldownText = frame:CreateFontString(nil, "OVERLAY", "GameFontHighlightLarge")
-  frame.cooldownText:SetPoint("CENTER", frame, "CENTER", 0, 0)
-  frame.cooldownText:SetFont(GameFontHighlightLarge:GetFont(), 16, "OUTLINE")
-  frame.cooldownText:SetDrawLayer("OVERLAY", 8)
-  frame.cooldownText:Hide()
-
-  -- === STATE ===
-  frame._cooldownEnd = nil
-  frame.isGlowing = false
-  frame.data = data
-
-  -- === ONUPDATE: drive cooldown text ===
-  frame:SetScript("OnUpdate", function(self)
-    if self._cooldownEnd then
-      local remain = self._cooldownEnd - GetTime()
-      if remain <= 0 then
-        self._cooldownEnd = nil
-        self.cooldownText:Hide()
-        self.icon:SetDesaturated(false)
-      else
-        self.cooldownText:SetText(FormatSeconds(remain))
-        self.cooldownText:Show()
-      end
-    end
-  end)
-
-
-  return frame
-end
-
-
-
-local function LayoutTopBarSpells(frames)
-  if not UI.attachments or not UI.attachments.TOP then return end
-
-  local width    = ClassHUD.db.profile.width
-  local perRow   = (ClassHUD.db.profile.topBar and ClassHUD.db.profile.topBar.perRow) or 8
-  local spacingX = (ClassHUD.db.profile.topBar and ClassHUD.db.profile.topBar.spacingX) or 4
-  local spacingY = (ClassHUD.db.profile.topBar and ClassHUD.db.profile.topBar.spacingY) or 4
-  local yOffset  = (ClassHUD.db.profile.topBar and ClassHUD.db.profile.topBar.yOffset) or 0
-
-  local size     = (width - (perRow - 1) * spacingX) / perRow
-
-  local row, col = 0, 0
-  for i, frame in ipairs(frames) do
-    frame:SetSize(size, size)
-    frame:ClearAllPoints()
-
-    local rowCount = math.min(perRow, #frames - row * perRow)
-    local rowWidth = rowCount * size + (rowCount - 1) * spacingX
-    local startX   = (width - rowWidth) / 2
-
-    frame:SetPoint("BOTTOMLEFT",
-      UI.attachments.TOP, "TOPLEFT",
-      startX + col * (size + spacingX),
-      row * (size + spacingY) + spacingY + yOffset)
-
-    col = col + 1
-    if col >= perRow then
-      col = 0
-      row = row + 1
-    end
-  end
-end
-
-local function LayoutSideBarSpells(frames, side)
-  if not UI.attachments or not UI.attachments[side] then return end
-
-  local size    = (ClassHUD.db.profile.sideBars and ClassHUD.db.profile.sideBars.size) or 36
-  local spacing = (ClassHUD.db.profile.sideBars and ClassHUD.db.profile.sideBars.spacing) or 4
-  local offset  = (ClassHUD.db.profile.sideBars and ClassHUD.db.profile.sideBars.offset) or 6
-
-  for i, frame in ipairs(frames) do
-    frame:SetSize(size, size)
-    frame:ClearAllPoints()
-
-    if side == "LEFT" then
-      frame:SetPoint("TOPRIGHT",
-        UI.attachments.LEFT, "TOPLEFT",
-        -offset, -(i - 1) * (size + spacing))
-    elseif side == "RIGHT" then
-      frame:SetPoint("TOPLEFT",
-        UI.attachments.RIGHT, "TOPRIGHT",
-        offset, -(i - 1) * (size + spacing))
-    end
-  end
-end
-
-local function LayoutBottomBarSpells(frames)
-  if not UI.attachments or not UI.attachments.BOTTOM then return end
-
-  local width    = ClassHUD.db.profile.width
-  local perRow   = (ClassHUD.db.profile.bottomBar and ClassHUD.db.profile.bottomBar.perRow) or 8
-  local spacingX = (ClassHUD.db.profile.bottomBar and ClassHUD.db.profile.bottomBar.spacingX) or 4
-  local spacingY = (ClassHUD.db.profile.bottomBar and ClassHUD.db.profile.bottomBar.spacingY) or 4
-  local yOffset  = (ClassHUD.db.profile.bottomBar and ClassHUD.db.profile.bottomBar.yOffset) or 0
-
-  local size     = (width - (perRow - 1) * spacingX) / perRow
-
-  local row, col = 0, 0
-  for i, frame in ipairs(frames) do
-    frame:SetSize(size, size)
-    frame:ClearAllPoints()
-
-    local rowCount = math.min(perRow, #frames - row * perRow)
-    local rowWidth = rowCount * size + (rowCount - 1) * spacingX
-    local startX   = (width - rowWidth) / 2
-
-    frame:SetPoint("TOPLEFT",
-      UI.attachments.BOTTOM, "BOTTOMLEFT",
-      startX + col * (size + spacingX),
-      -(row * (size + spacingY) + spacingY + yOffset))
-
-    col = col + 1
-    if col >= perRow then
-      col = 0
-      row = row + 1
-    end
-  end
-end
-
--- Return start, duration, enabled(1/0), modRate for a spellID.
-local function ReadCooldown(spellID)
-  if not spellID or not C_Spell then return 0, 0, 0, 1, nil end
-
-  local start, duration, enabled, modRate, charges
-
-  -- Primary cooldown info
-  local cd = C_Spell.GetSpellCooldown(spellID)
-  if type(cd) == "table" then
-    start    = cd.startTime or 0
-    duration = cd.duration or 0
-    enabled  = cd.isEnabled and 1 or 0
-    modRate  = cd.modRate or 1
-  end
-
-  -- Charges override
-  if C_Spell.GetSpellCharges then
-    local ch = C_Spell.GetSpellCharges(spellID)
-    if type(ch) == "table" and ch.maxCharges and ch.currentCharges then
-      charges = ch
-      if ch.currentCharges < ch.maxCharges then
-        start    = ch.cooldownStartTime or start
-        duration = ch.cooldownDuration or duration
-        enabled  = 1
-        modRate  = ch.chargeModRate or modRate or 1
-      end
-    end
-  end
-
-  return start or 0, duration or 0, enabled or 0, modRate or 1, charges
-end
-
-
-local function UpdateSpellFrame(frame)
-  local data = frame.data
-  if not data or not data.spellID then return end
-
-  -- === ICON ===
-  local iconID = GetSpellIcon(data.spellID)
-  frame.icon:SetTexture(iconID)
-  frame.icon:SetDesaturated(false)
-
-  -- === COOLDOWN TRACKING ===
-  if data.trackCooldown then
-    local start, duration, enabled, modRate = ReadCooldown(data.spellID)
-
-    if enabled == 1 and start > 0 and duration > 1.45 then
-      -- Spiral
-      CooldownFrame_Set(frame.cooldown, start, duration, true)
-      -- Numeric countdown
-      frame._cooldownEnd = start + (duration / (modRate or 1))
-      frame.cooldownText:Show()
-      -- Desaturate while on cooldown
-      frame.icon:SetDesaturated(true)
-    else
-      CooldownFrame_Clear(frame.cooldown)
-      frame._cooldownEnd = nil
-      frame.cooldownText:Hide()
-      frame.icon:SetDesaturated(false)
-    end
-  else
-    CooldownFrame_Clear(frame.cooldown)
-    frame._cooldownEnd = nil
-    frame.cooldownText:Hide()
-    frame.icon:SetDesaturated(false)
-  end
-
-  -- === AURA STACK COUNT ===
-  if data.countFromAura and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID then
-    local aura = C_UnitAuras.GetPlayerAuraBySpellID(data.countFromAura)
-    local stacks = (aura and aura.applications) or 0
-    if stacks > 0 then
-      frame.count:SetText(stacks)
-      frame.count:Show()
-    else
-      frame.count:SetText("")
-      frame.count:Hide()
-    end
-  else
-    frame.count:SetText("")
-    frame.count:Hide()
-  end
-
-  -- === AURA GLOW ===
-  -- === AURA GLOW ===
-  if data.auraGlow and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID then
-    local aura = C_UnitAuras.GetPlayerAuraBySpellID(data.auraGlow)
-    if aura then
-      ActionButtonSpellAlertManager:ShowAlert(frame)
-      frame.isGlowing = true
-      -- ICON SWAP
-      if aura.icon then
-        frame.icon:SetTexture(aura.icon)
-      end
-    elseif frame.isGlowing then
-      ActionButtonSpellAlertManager:HideAlert(frame)
-      frame.isGlowing = false
-      -- Restore normal icon
-      frame.icon:SetTexture(GetSpellIcon(data.spellID))
-    end
-  end
-end
-
-
-
-function ClassHUD:UpdateAllFrames()
-  for _, f in ipairs(activeFrames) do UpdateSpellFrame(f) end
-end
-
-function ClassHUD:BuildFramesForSpec()
-  for _, f in ipairs(activeFrames) do f:Hide() end
-  wipe(activeFrames)
-
-  local specIndex = GetSpecialization()
-  local specID = specIndex and GetSpecializationInfo(specIndex) or 0
-  -- Top bar
-  local top = self.db.profile.topBarSpells[specID]
-  if top then
-    local frames = {}
-    for i, data in ipairs(top) do
-      if C_SpellBook.IsSpellKnown(data.spellID) or C_SpellBook.IsSpellInSpellBook(data.spellID) then
-        local frame = CreateSpellFrame(data, #activeFrames + 1)
-        table.insert(frames, frame)
-        table.insert(activeFrames, frame)
-      end
-    end
-    LayoutTopBarSpells(frames)
-  end
-
-  -- Left bar
-  local left = self.db.profile.leftBarSpells[specID]
-  if left then
-    local frames = {}
-    for i, data in ipairs(left) do
-      if C_SpellBook.IsSpellKnown(data.spellID) or C_SpellBook.IsSpellInSpellBook(data.spellID) then
-        local frame = CreateSpellFrame(data, #activeFrames + 1)
-        table.insert(frames, frame)
-        table.insert(activeFrames, frame)
-      end
-    end
-    LayoutSideBarSpells(frames, "LEFT")
-  end
-
-  -- Right bar
-  local right = self.db.profile.rightBarSpells[specID]
-  if right then
-    local frames = {}
-    for i, data in ipairs(right) do
-      if C_SpellBook.IsSpellKnown(data.spellID) or C_SpellBook.IsSpellInSpellBook(data.spellID) then
-        local frame = CreateSpellFrame(data, #activeFrames + 1)
-        table.insert(frames, frame)
-        table.insert(activeFrames, frame)
-      end
-    end
-    LayoutSideBarSpells(frames, "RIGHT")
-  end
-
-  -- Bottom bar
-  local bottom = self.db.profile.bottomBarSpells[specID]
-  if bottom then
-    local frames = {}
-    for i, data in ipairs(bottom) do
-      if C_SpellBook.IsSpellKnown(data.spellID) or C_SpellBook.IsSpellInSpellBook(data.spellID) then
-        local frame = CreateSpellFrame(data, #activeFrames + 1)
-        table.insert(frames, frame)
-        table.insert(activeFrames, frame)
-      end
-    end
-    LayoutBottomBarSpells(frames)
-  end
-
-
-  self:UpdateAllFrames()
-end
-
--- Module enable
 function ClassHUD:OnEnable()
-  -- ============= Bars ============
-  if not UI.anchor then
-    CreateAnchor()
-  end
-
-  if not UI.cast then CreateCastBar() end
-  if not UI.hp then CreateHPBar() end
-  if not UI.resource then CreateResourceBar() end
-  if not UI.power then CreatePowerContainer() end
-  Layout()
-  ApplyBarSkins()
+  self:CreateAnchor()
+  self:CreateCastBar()
+  self:CreateHPBar()
+  self:CreateResourceBar()
+  self:CreatePowerContainer()
+  self:LayoutBars()
+  self:ApplyBarSkins()
 end
 
--- EVENT HANDLER ------------------
 local eventFrame = CreateFrame("Frame")
 
 for _, ev in pairs({
@@ -1185,10 +247,6 @@ end
 
 
 eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
-  -- Debug (optional)
-  -- print("Event fired:", event, unit)
-
-  -- Full refresh after world load
   if event == "PLAYER_ENTERING_WORLD" then
     ClassHUD:FullUpdate()
     ClassHUD:ApplyAnchorPosition()
@@ -1196,72 +254,67 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
     return
   end
 
-  -- Spec change
   if event == "PLAYER_SPECIALIZATION_CHANGED" and unit == "player" then
-    UpdatePrimaryResource()
-    UpdateSpecialPower()
+    ClassHUD:UpdatePrimaryResource()
+    ClassHUD:UpdateSpecialPower()
     ClassHUD:BuildFramesForSpec()
     return
   end
 
-  -- Health
   if event == "UNIT_HEALTH" or event == "UNIT_MAXHEALTH" then
-    if unit == "player" then UpdateHP() end
+    if unit == "player" then ClassHUD:UpdateHP() end
     return
   end
 
-  -- Resources
   if event == "UNIT_POWER_FREQUENT" or event == "UNIT_DISPLAYPOWER" then
     if unit == "player" then
-      UpdatePrimaryResource()
-      UpdateSpecialPower()
+      ClassHUD:UpdatePrimaryResource()
+      ClassHUD:UpdateSpecialPower()
     end
     return
   end
 
   if event == "UPDATE_SHAPESHIFT_FORM" then
-    UpdatePrimaryResource()
-    UpdateSpecialPower()
+    ClassHUD:UpdatePrimaryResource()
+    ClassHUD:UpdateSpecialPower()
     return
   end
 
   if event == "UNIT_POWER_POINT_CHARGE" and unit == "player" then
-    UpdateSpecialPower()
+    ClassHUD:UpdateSpecialPower()
     return
   end
 
   if event == "RUNE_POWER_UPDATE" or event == "RUNE_TYPE_UPDATE" then
-    UpdateSpecialPower()
+    ClassHUD:UpdateSpecialPower()
     return
   end
 
-  -- Castbar
   if event == "UNIT_SPELLCAST_START" then
-    ClassHUD:UNIT_SPELLCAST_START(_, unit)
+    ClassHUD:UNIT_SPELLCAST_START(event, unit, ...)
     return
   end
   if event == "UNIT_SPELLCAST_STOP" then
-    ClassHUD:UNIT_SPELLCAST_STOP(_, unit)
+    ClassHUD:UNIT_SPELLCAST_STOP(event, unit, ...)
     return
   end
   if event == "UNIT_SPELLCAST_CHANNEL_START" then
-    ClassHUD:UNIT_SPELLCAST_CHANNEL_START(_, unit)
+    ClassHUD:UNIT_SPELLCAST_CHANNEL_START(event, unit, ...)
     return
   end
   if event == "UNIT_SPELLCAST_CHANNEL_STOP" then
-    ClassHUD:UNIT_SPELLCAST_CHANNEL_STOP(_, unit)
+    ClassHUD:UNIT_SPELLCAST_CHANNEL_STOP(event, unit, ...)
     return
   end
   if event == "UNIT_SPELLCAST_INTERRUPTED" then
-    ClassHUD:UNIT_SPELLCAST_INTERRUPTED(_, unit)
+    ClassHUD:UNIT_SPELLCAST_INTERRUPTED(event, unit, ...)
     return
   end
   if event == "UNIT_SPELLCAST_FAILED" then
-    ClassHUD:UNIT_SPELLCAST_FAILED(_, unit)
+    ClassHUD:UNIT_SPELLCAST_FAILED(event, unit, ...)
     return
   end
 
-  -- Spells (auras + cooldowns)
   if event == "UNIT_AURA" and unit == "player" then
     ClassHUD:UpdateAllFrames()
     return
@@ -1272,8 +325,6 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
   end
 end)
 
-
--- Replace your slash handler with this
 SLASH_CLASSHUD1 = "/chud"
 SlashCmdList["CLASSHUD"] = function(msg)
   if msg == "debug" then

--- a/ClassHUD.toc
+++ b/ClassHUD.toc
@@ -9,5 +9,8 @@
 ## OptionalDeps: LibSharedMedia-3.0
 
 ClassHUD.lua
+ClassHUD_Bars.lua
+ClassHUD_Classbar.lua
+ClassHUD_Spells.lua
 ClassHUD_SpellSuggestions.lua
 ClassHUD_Options.lua

--- a/ClassHUD_Bars.lua
+++ b/ClassHUD_Bars.lua
@@ -1,0 +1,283 @@
+local addon = ClassHUD
+local UI = addon.UI
+
+function addon:ApplyAnchorPosition()
+  if not UI.anchor then return end
+  local pos = self.db.profile.position or { x = 0, y = -350 }
+  UI.anchor:ClearAllPoints()
+  UI.anchor:SetPoint("CENTER", UIParent, "CENTER", pos.x or 0, pos.y or 0)
+end
+
+function addon:CreateAnchor()
+  if UI.anchor then return UI.anchor end
+  local f = CreateFrame("Frame", "ClassHUDAnchor", UIParent, "BackdropTemplate")
+  f:SetSize(self.db and self.db.profile and self.db.profile.width or 250, 1)
+  f:SetMovable(false)
+  UI.anchor = f
+  return f
+end
+
+function addon:CreateStatusBar(parent, height)
+  local bar = CreateFrame("StatusBar", nil, parent, "BackdropTemplate")
+  bar:SetStatusBarTexture(self:FetchStatusbar())
+  bar:SetMinMaxValues(0, 1)
+  bar:SetValue(0)
+  bar.bg = bar:CreateTexture(nil, "BACKGROUND")
+  bar.bg:SetAllPoints(true)
+  bar.bg:SetColorTexture(0, 0, 0, 0.55)
+
+  bar.text = bar:CreateFontString(nil, "OVERLAY")
+  bar.text:SetPoint("CENTER")
+  bar.text:SetFont(self:FetchFont(12))
+
+  bar:SetHeight(height)
+  bar:SetWidth(self.db.profile.width)
+  return bar
+end
+
+function addon:CreateCastBar()
+  if UI.cast then return UI.cast end
+  local h = self.db.profile.height.cast
+  local b = self:CreateStatusBar(UI.anchor, h)
+
+  b.icon = b:CreateTexture(nil, "ARTWORK")
+  b.icon:SetSize(h, h)
+  b.icon:SetPoint("LEFT", b, "LEFT", 0, 0)
+  b.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
+
+  b.spell = b:CreateFontString(nil, "OVERLAY")
+  b.spell:SetFont(self:FetchFont(12))
+  b.spell:SetPoint("LEFT", b.icon, "RIGHT", 4, 0)
+  b.spell:SetJustifyH("LEFT")
+
+  b.time = b:CreateFontString(nil, "OVERLAY")
+  b.time:SetFont(self:FetchFont(12))
+  b.time:SetPoint("RIGHT", b, "RIGHT", -3, 0)
+  b.time:SetJustifyH("RIGHT")
+
+  b:SetStatusBarColor(1, .7, 0)
+  b:Hide()
+  UI.cast = b
+  return b
+end
+
+function addon:CreateHPBar()
+  if UI.hp then return UI.hp end
+  local b = self:CreateStatusBar(UI.anchor, self.db.profile.height.hp)
+  local r, g, bCol = self:GetClassColor()
+  b:SetStatusBarColor(r, g, bCol)
+  UI.hp = b
+  return b
+end
+
+function addon:CreateResourceBar()
+  if UI.resource then return UI.resource end
+  local b = self:CreateStatusBar(UI.anchor, self.db.profile.height.resource)
+  if self.db.profile.colors.resourceClass then
+    b:SetStatusBarColor(self:GetClassColor())
+  else
+    local c = self.db.profile.colors.resource
+    b:SetStatusBarColor(c.r, c.g, c.b)
+  end
+  UI.resource = b
+  return b
+end
+
+function addon:ApplyBarSkins()
+  local tex = self:FetchStatusbar()
+  for _, sb in pairs({ UI.cast, UI.hp, UI.resource }) do
+    if sb and sb.SetStatusBarTexture then
+      sb:SetStatusBarTexture(tex)
+    end
+  end
+  if UI.cast then
+    UI.cast.spell:SetFont(self:FetchFont(12))
+    UI.cast.time:SetFont(self:FetchFont(12))
+  end
+  if UI.hp then UI.hp.text:SetFont(self:FetchFont(12)) end
+  if UI.resource then UI.resource.text:SetFont(self:FetchFont(12)) end
+end
+
+function addon:LayoutBars()
+  local w   = self.db.profile.width
+  local gap = self.db.profile.spacing
+
+  UI.anchor:SetWidth(w)
+
+  local y = 0
+
+  if self.db.profile.show.cast then
+    UI.cast:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
+    UI.cast:SetWidth(w)
+    UI.cast:SetHeight(self.db.profile.height.cast)
+    y = y + UI.cast:GetHeight() + gap
+  else
+    UI.cast:ClearAllPoints(); UI.cast:Hide()
+  end
+
+  if self.db.profile.show.hp then
+    UI.hp:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
+    UI.hp:SetWidth(w)
+    UI.hp:SetHeight(self.db.profile.height.hp)
+    y = y + UI.hp:GetHeight() + gap
+  else
+    UI.hp:ClearAllPoints(); UI.hp:Hide()
+  end
+
+  if self.db.profile.show.resource then
+    UI.resource:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
+    UI.resource:SetWidth(w)
+    UI.resource:SetHeight(self.db.profile.height.resource)
+    y = y + UI.resource:GetHeight() + gap
+  else
+    UI.resource:ClearAllPoints(); UI.resource:Hide()
+  end
+
+  if self.db.profile.show.power then
+    UI.power:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
+    UI.power:SetWidth(w)
+    UI.power:SetHeight(self.db.profile.height.power)
+  else
+    UI.power:ClearAllPoints(); UI.power:Hide()
+  end
+
+  local function ensure(name)
+    if not UI.attachments[name] then
+      UI.attachments[name] = CreateFrame("Frame", "ClassHUDAttach" .. name, UI.anchor)
+      UI.attachments[name]:SetSize(1, 1)
+    end
+    return UI.attachments[name]
+  end
+
+  local top = ensure("TOP")
+  top:ClearAllPoints()
+  top:SetPoint("BOTTOMLEFT", UI.cast, "TOPLEFT", 0, 0)
+  top:SetPoint("BOTTOMRIGHT", UI.cast, "TOPRIGHT", 0, 0)
+  top:SetHeight(1)
+
+  local bottom = ensure("BOTTOM")
+  bottom:ClearAllPoints()
+  bottom:SetPoint("TOPLEFT", UI.power, "BOTTOMLEFT", 0, 0)
+  bottom:SetPoint("TOPRIGHT", UI.power, "BOTTOMRIGHT", 0, 0)
+  bottom:SetHeight(1)
+
+  local left = ensure("LEFT")
+  left:ClearAllPoints()
+  left:SetPoint("RIGHT", UI.anchor, "LEFT", -4, 0)
+
+  local right = ensure("RIGHT")
+  right:ClearAllPoints()
+  right:SetPoint("LEFT", UI.anchor, "RIGHT", 4, 0)
+
+  self:ApplyBarSkins()
+end
+
+function addon:StopCast()
+  local casting = UnitCastingInfo("player")
+  local channeling = UnitChannelInfo("player")
+  if casting or channeling then
+    return
+  end
+
+  if UI.cast then
+    UI.cast:SetScript("OnUpdate", nil)
+    UI.cast:Hide()
+    UI.cast:SetValue(0)
+    UI.cast.time:SetText("")
+    UI.cast.spell:SetText("")
+    UI.cast.icon:SetTexture(nil)
+  end
+end
+
+function addon:StartCast(name, icon, startMS, endMS)
+  if not self.db.profile.show.cast then return end
+  local total = (endMS - startMS) / 1000
+  local start = startMS / 1000
+
+  UI.cast:Show()
+  UI.cast.spell:SetText(name or "")
+  UI.cast.icon:SetTexture(icon or 136243)
+  UI.cast:SetStatusBarColor(1, .7, 0)
+
+  UI.cast:SetScript("OnUpdate", function(selfBar)
+    local now = GetTime()
+    local elapsed = now - start
+    selfBar:SetMinMaxValues(0, total)
+    selfBar:SetValue(elapsed)
+    selfBar.time:SetFormattedText("%.1f / %.1f", math.max(0, elapsed), total)
+
+    if elapsed >= total then
+      selfBar:SetScript("OnUpdate", nil)
+      selfBar:Hide()
+    end
+  end)
+end
+
+function addon:UNIT_SPELLCAST_START(_, unit)
+  if unit ~= "player" then return end
+  local name, _, icon, startMS, endMS = UnitCastingInfo("player")
+  if name then
+    self:StartCast(name, icon, startMS, endMS)
+  end
+end
+
+function addon:UNIT_SPELLCAST_CHANNEL_START(_, unit)
+  if unit ~= "player" then return end
+  local name, _, icon, startMS, endMS = UnitChannelInfo("player")
+  if name then
+    self:StartCast(name, icon, startMS, endMS)
+  end
+end
+
+function addon:UNIT_SPELLCAST_SUCCEEDED(_, unit, spellID)
+  if unit ~= "player" then return end
+  local name, _, icon = C_Spell.GetSpellInfo(spellID)
+  if name and not UnitCastingInfo("player") and not UnitChannelInfo("player") then
+    local now = GetTime() * 1000
+    self:StartCast(name, icon, now, now + 1000)
+  end
+end
+
+function addon:UNIT_SPELLCAST_STOP(_, unit)
+  if unit == "player" then self:StopCast() end
+end
+
+function addon:UNIT_SPELLCAST_CHANNEL_STOP(_, unit)
+  if unit == "player" then self:StopCast() end
+end
+
+function addon:UNIT_SPELLCAST_INTERRUPTED(_, unit)
+  if unit == "player" then self:StopCast() end
+end
+
+function addon:UNIT_SPELLCAST_FAILED(_, unit)
+  if unit == "player" then self:StopCast() end
+end
+
+function addon:UpdateHP()
+  if not self.db.profile.show.hp then return end
+  local cur, max = UnitHealth("player"), UnitHealthMax("player")
+  UI.hp:SetMinMaxValues(0, max)
+  UI.hp:SetValue(cur)
+  local pct = (max > 0) and (cur / max * 100) or 0
+  UI.hp.text:SetFormattedText("%d%%", pct + 0.5)
+end
+
+function addon:UpdatePrimaryResource()
+  if not self.db.profile.show.resource then return end
+
+  local id, token = UnitPowerType("player")
+  local cur, max = UnitPower("player", id), UnitPowerMax("player", id)
+  UI.resource:SetMinMaxValues(0, max > 0 and max or 1)
+  UI.resource:SetValue(cur)
+
+  local r, g, b = self:PowerColorBy(id, token)
+  UI.resource:SetStatusBarColor(r, g, b)
+
+  if id == Enum.PowerType.Mana then
+    local pct = (max > 0) and (cur / max * 100) or 0
+    UI.resource.text:SetFormattedText("%d%%", pct + 0.5)
+  else
+    UI.resource.text:SetText(cur)
+  end
+end

--- a/ClassHUD_Classbar.lua
+++ b/ClassHUD_Classbar.lua
@@ -1,0 +1,256 @@
+local addon = ClassHUD
+local UI = addon.UI
+
+function addon:CreatePowerContainer()
+  if UI.power then return UI.power end
+  local f = CreateFrame("Frame", nil, UI.anchor, "BackdropTemplate")
+  f:SetSize(self.db.profile.width, self.db.profile.height.power)
+  UI.power = f
+  return f
+end
+
+local function EnsureSegment(i)
+  if not UI.powerSegments[i] then
+    local sb = addon:CreateStatusBar(UI.power, addon.db.profile.height.power)
+    sb.text:Hide()
+    UI.powerSegments[i] = sb
+  end
+  return UI.powerSegments[i]
+end
+
+local function HideAllSegments(from)
+  for i = from, #UI.powerSegments do
+    if UI.powerSegments[i] then UI.powerSegments[i]:Hide() end
+  end
+end
+
+local CLASS_POWER_ID = {
+  MONK        = Enum.PowerType.Chi,
+  PALADIN     = Enum.PowerType.HolyPower,
+  WARLOCK     = Enum.PowerType.SoulShards,
+  ROGUE       = Enum.PowerType.ComboPoints,
+  DRUID       = Enum.PowerType.ComboPoints,
+  MAGE        = Enum.PowerType.ArcaneCharges,
+  EVOKER      = Enum.PowerType.Essence,
+  DEATHKNIGHT = Enum.PowerType.Runes,
+}
+
+local REQUIRED_SPEC = {
+  MONK = 269,
+  MAGE = 62,
+}
+
+local USES_PARTIAL_BY_SPEC = {
+  [267] = true,
+}
+
+local CHARGED_CP_COLOR = { 1.0, 0.95, 0.35 }
+
+local RESOURCE_BASE_COLORS = {
+  [Enum.PowerType.HolyPower]     = { 1.00, 0.88, 0.25 },
+  [Enum.PowerType.SoulShards]    = { 0.60, 0.22, 1.00 },
+  [Enum.PowerType.ArcaneCharges] = { 0.25, 0.60, 1.00 },
+  [Enum.PowerType.Essence]       = { 0.50, 1.00, 0.90 },
+}
+
+local function RuneSpecColor(specID)
+  if specID == 250 then return 0.75, 0.10, 0.10 end
+  if specID == 251 then return 0.35, 0.70, 1.00 end
+  if specID == 252 then return 0.20, 0.95, 0.35 end
+  return 0.7, 0.7, 0.7
+end
+
+local function IndexedColor(i, max)
+  if max <= 1 then return 1, 1, 1 end
+  local t = (i - 1) / (max - 1)
+  local r = 1.0
+  local g = math.min(1, 0.1 + 0.9 * t)
+  local b = math.max(0, 0.05 + 0.25 * (1 - t))
+  return r, g, b
+end
+
+local function GetChargedPoints()
+  if not GetUnitChargedPowerPoints then return nil end
+  return GetUnitChargedPowerPoints("player")
+end
+
+local function SegmentColor(i, max, ptype, class, specID, chargedPoints)
+  if ptype == Enum.PowerType.Runes then
+    return RuneSpecColor(specID)
+  end
+  if ptype == Enum.PowerType.ComboPoints or ptype == Enum.PowerType.Chi or ptype == Enum.PowerType.ArcaneCharges then
+    if ptype == Enum.PowerType.ComboPoints and chargedPoints then
+      for _, idx in ipairs(chargedPoints) do
+        if idx == i then return unpack(CHARGED_CP_COLOR) end
+      end
+    end
+    return IndexedColor(i, max)
+  end
+  local base = RESOURCE_BASE_COLORS[ptype]
+  if base then return unpack(base) end
+  return addon:PowerColorBy(ptype)
+end
+
+local function UpdateSegmentsAdvanced(ptype, max, partial)
+  if not max or max <= 0 then
+    HideAllSegments(1)
+    UI.power:Hide()
+    return
+  end
+
+  local w = addon.db.profile.width
+  local gap = addon.db.profile.powerSpacing or 1
+  local segW = (w - gap * (max - 1)) / max
+
+  local _, class = UnitClass("player")
+  local spec = GetSpecialization()
+  local specID = spec and GetSpecializationInfo(spec) or 0
+  local charged = (ptype == Enum.PowerType.ComboPoints and class == "ROGUE") and GetChargedPoints() or nil
+  local cur = UnitPower("player", ptype, partial and true or false)
+
+  local whole, frac = 0, 0
+  if partial then
+    local mod   = UnitPowerDisplayMod(ptype) or 1
+    local exact = cur / mod
+    whole       = math.floor(exact)
+    frac        = exact - whole
+  end
+
+  for i = 1, max do
+    local sb = EnsureSegment(i)
+    sb:SetStatusBarTexture(addon:FetchStatusbar())
+    sb:SetSize(segW, addon.db.profile.height.power)
+    sb:ClearAllPoints()
+    if i == 1 then
+      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
+    else
+      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
+    end
+    local r, g, b = SegmentColor(i, max, ptype, class, specID, charged)
+    sb:SetStatusBarColor(r, g, b)
+    sb:SetMinMaxValues(0, 1)
+    sb:Show()
+
+    if partial then
+      if i <= whole then
+        sb:SetValue(1)
+      elseif i == whole + 1 then
+        sb:SetValue(frac)
+      else
+        sb:SetValue(0)
+      end
+    else
+      sb:SetValue(cur >= i and 1 or 0)
+    end
+  end
+  HideAllSegments(max + 1)
+end
+
+local function UpdateEssenceSegments(ptype)
+  local max = UnitPowerMax("player", ptype)
+  if not max or max <= 0 then
+    HideAllSegments(1)
+    UI.power:Hide()
+    return
+  end
+  local w = addon.db.profile.width
+  local gap = addon.db.profile.powerSpacing or 1
+  local segW = (w - gap * (max - 1)) / max
+  local cur = UnitPower("player", ptype)
+  local partial = UnitPartialPower and (UnitPartialPower("player", ptype) or 0) or 0
+  local nextFrac = partial / 1000.0
+  local base = RESOURCE_BASE_COLORS[ptype] or { 0.5, 1, 0.9 }
+  local r, g, b = base[1], base[2], base[3]
+  for i = 1, max do
+    local sb = EnsureSegment(i)
+    sb:SetStatusBarTexture(addon:FetchStatusbar())
+    sb:SetSize(segW, addon.db.profile.height.power)
+    sb:ClearAllPoints()
+    if i == 1 then
+      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
+    else
+      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
+    end
+    sb:SetMinMaxValues(0, 1)
+    sb:SetStatusBarColor(r, g, b)
+    sb:Show()
+    if i <= cur then
+      sb:SetValue(1)
+    elseif i == cur + 1 and cur < max then
+      sb:SetValue(nextFrac)
+    else
+      sb:SetValue(0)
+    end
+  end
+  HideAllSegments(max + 1)
+end
+
+local function UpdateRunes()
+  local spec = GetSpecialization()
+  local specID = spec and GetSpecializationInfo(spec) or 0
+  local rr, rg, rb = RuneSpecColor(specID)
+  local gap = 2
+  local max = 6
+  local w = addon.db.profile.width
+  local segW = (w - gap * (max - 1)) / max
+  for i = 1, max do
+    local sb = EnsureSegment(i)
+    sb:SetStatusBarTexture(addon:FetchStatusbar())
+    sb:SetSize(segW, addon.db.profile.height.power)
+    sb:ClearAllPoints()
+    if i == 1 then
+      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
+    else
+      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
+    end
+    local start, duration, ready = GetRuneCooldown(i)
+    sb:SetMinMaxValues(0, 1)
+    if ready then
+      sb:SetValue(1)
+      sb:SetStatusBarColor(rr, rg, rb)
+    elseif start and duration and duration > 0 then
+      local elapsed = GetTime() - start
+      sb:SetValue(math.min(elapsed / duration, 1))
+      sb:SetStatusBarColor(rr * 0.5, rg * 0.5, rb * 0.5)
+    else
+      sb:SetValue(1)
+      sb:SetStatusBarColor(rr, rg, rb)
+    end
+    sb:Show()
+  end
+  HideAllSegments(max + 1)
+end
+
+local function ResolveSpecialPower()
+  local _, class = UnitClass("player")
+  local spec = GetSpecialization()
+  local specID = spec and GetSpecializationInfo(spec) or 0
+  local ptype = CLASS_POWER_ID[class]
+  if not ptype then return nil end
+  if REQUIRED_SPEC[class] and specID ~= REQUIRED_SPEC[class] then return nil end
+  if class == "DRUID" and select(1, UnitPowerType("player")) ~= Enum.PowerType.Energy then
+    return nil
+  end
+  return ptype, specID
+end
+
+function addon:UpdateSpecialPower()
+  if not self.db.profile.show.power then return end
+  local ptype, specID = ResolveSpecialPower()
+  if not ptype then
+    HideAllSegments(1)
+    UI.power:Hide()
+    return
+  end
+  UI.power:Show()
+  if ptype == Enum.PowerType.Runes then
+    UpdateRunes()
+    return
+  elseif ptype == Enum.PowerType.Essence then
+    UpdateEssenceSegments(ptype)
+    return
+  end
+  local max = UnitPowerMax("player", ptype) or 0
+  local usePartial = USES_PARTIAL_BY_SPEC[specID] or false
+  UpdateSegmentsAdvanced(ptype, max, usePartial)
+end

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -1,0 +1,315 @@
+local addon = ClassHUD
+local UI = addon.UI
+local ADDON_NAME = addon.ADDON_NAME
+
+local activeFrames = {}
+
+local function GetSpellIcon(spellID)
+  local info = C_Spell.GetSpellInfo(spellID)
+  return info and info.iconID or 134400
+end
+
+local function FormatSeconds(s)
+  if s >= 60 then
+    return string.format("%dm", math.ceil(s / 60))
+  elseif s >= 10 then
+    return tostring(math.floor(s + 0.5))
+  else
+    return string.format("%.1f", s)
+  end
+end
+
+local function CreateSpellFrame(data, index)
+  local frame = CreateFrame("Frame", ADDON_NAME .. "Spell" .. index, UIParent)
+
+  frame:SetSize(40, 40)
+  frame:SetPoint("CENTER", UIParent, "CENTER")
+
+  frame.icon = frame:CreateTexture(nil, "ARTWORK")
+  frame.icon:SetAllPoints(frame)
+
+  frame.count = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+  frame.count:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -2, 2)
+  frame.count:SetFont(GameFontNormalLarge:GetFont(), 14, "OUTLINE")
+  frame.count:SetDrawLayer("OVERLAY", 7)
+  frame.count:Hide()
+
+  frame.cooldown = CreateFrame("Cooldown", nil, frame, "CooldownFrameTemplate")
+  frame.cooldown:SetAllPoints(frame)
+  frame.cooldown:SetHideCountdownNumbers(true)
+  frame.cooldown.noCooldownCount = true
+  frame.cooldown:SetDrawEdge(false)
+
+  local lvl = frame:GetFrameLevel()
+  frame.cooldown:SetFrameLevel(lvl + 1)
+
+  frame.cooldownText = frame:CreateFontString(nil, "OVERLAY", "GameFontHighlightLarge")
+  frame.cooldownText:SetPoint("CENTER", frame, "CENTER", 0, 0)
+  frame.cooldownText:SetFont(GameFontHighlightLarge:GetFont(), 16, "OUTLINE")
+  frame.cooldownText:SetDrawLayer("OVERLAY", 8)
+  frame.cooldownText:Hide()
+
+  frame._cooldownEnd = nil
+  frame.isGlowing = false
+  frame.data = data
+
+  frame:SetScript("OnUpdate", function(selfFrame)
+    if selfFrame._cooldownEnd then
+      local remain = selfFrame._cooldownEnd - GetTime()
+      if remain <= 0 then
+        selfFrame._cooldownEnd = nil
+        selfFrame.cooldownText:Hide()
+        selfFrame.icon:SetDesaturated(false)
+      else
+        selfFrame.cooldownText:SetText(FormatSeconds(remain))
+        selfFrame.cooldownText:Show()
+      end
+    end
+  end)
+
+  return frame
+end
+
+local function LayoutTopBarSpells(frames)
+  if not UI.attachments or not UI.attachments.TOP then return end
+
+  local width    = addon.db.profile.width
+  local perRow   = (addon.db.profile.topBar and addon.db.profile.topBar.perRow) or 8
+  local spacingX = (addon.db.profile.topBar and addon.db.profile.topBar.spacingX) or 4
+  local spacingY = (addon.db.profile.topBar and addon.db.profile.topBar.spacingY) or 4
+  local yOffset  = (addon.db.profile.topBar and addon.db.profile.topBar.yOffset) or 0
+
+  local size     = (width - (perRow - 1) * spacingX) / perRow
+
+  local row, col = 0, 0
+  for _, frame in ipairs(frames) do
+    frame:SetSize(size, size)
+    frame:ClearAllPoints()
+
+    local rowCount = math.min(perRow, #frames - row * perRow)
+    local rowWidth = rowCount * size + (rowCount - 1) * spacingX
+    local startX   = (width - rowWidth) / 2
+
+    frame:SetPoint("BOTTOMLEFT",
+      UI.attachments.TOP, "TOPLEFT",
+      startX + col * (size + spacingX),
+      row * (size + spacingY) + spacingY + yOffset)
+
+    col = col + 1
+    if col >= perRow then
+      col = 0
+      row = row + 1
+    end
+  end
+end
+
+local function LayoutSideBarSpells(frames, side)
+  if not UI.attachments or not UI.attachments[side] then return end
+
+  local size    = (addon.db.profile.sideBars and addon.db.profile.sideBars.size) or 36
+  local spacing = (addon.db.profile.sideBars and addon.db.profile.sideBars.spacing) or 4
+  local offset  = (addon.db.profile.sideBars and addon.db.profile.sideBars.offset) or 6
+
+  for i, frame in ipairs(frames) do
+    frame:SetSize(size, size)
+    frame:ClearAllPoints()
+
+    if side == "LEFT" then
+      frame:SetPoint("TOPRIGHT",
+        UI.attachments.LEFT, "TOPLEFT",
+        -offset, -(i - 1) * (size + spacing))
+    elseif side == "RIGHT" then
+      frame:SetPoint("TOPLEFT",
+        UI.attachments.RIGHT, "TOPRIGHT",
+        offset, -(i - 1) * (size + spacing))
+    end
+  end
+end
+
+local function LayoutBottomBarSpells(frames)
+  if not UI.attachments or not UI.attachments.BOTTOM then return end
+
+  local width    = addon.db.profile.width
+  local perRow   = (addon.db.profile.bottomBar and addon.db.profile.bottomBar.perRow) or 8
+  local spacingX = (addon.db.profile.bottomBar and addon.db.profile.bottomBar.spacingX) or 4
+  local spacingY = (addon.db.profile.bottomBar and addon.db.profile.bottomBar.spacingY) or 4
+  local yOffset  = (addon.db.profile.bottomBar and addon.db.profile.bottomBar.yOffset) or 0
+
+  local size     = (width - (perRow - 1) * spacingX) / perRow
+
+  local row, col = 0, 0
+  for _, frame in ipairs(frames) do
+    frame:SetSize(size, size)
+    frame:ClearAllPoints()
+
+    local rowCount = math.min(perRow, #frames - row * perRow)
+    local rowWidth = rowCount * size + (rowCount - 1) * spacingX
+    local startX   = (width - rowWidth) / 2
+
+    frame:SetPoint("TOPLEFT",
+      UI.attachments.BOTTOM, "BOTTOMLEFT",
+      startX + col * (size + spacingX),
+      -(row * (size + spacingY) + spacingY + yOffset))
+
+    col = col + 1
+    if col >= perRow then
+      col = 0
+      row = row + 1
+    end
+  end
+end
+
+local function ReadCooldown(spellID)
+  if not spellID or not C_Spell then return 0, 0, 0, 1, nil end
+
+  local start, duration, enabled, modRate, charges
+
+  local cd = C_Spell.GetSpellCooldown(spellID)
+  if type(cd) == "table" then
+    start    = cd.startTime or 0
+    duration = cd.duration or 0
+    enabled  = cd.isEnabled and 1 or 0
+    modRate  = cd.modRate or 1
+  end
+
+  if C_Spell.GetSpellCharges then
+    local ch = C_Spell.GetSpellCharges(spellID)
+    if type(ch) == "table" and ch.maxCharges and ch.currentCharges then
+      charges = ch
+      if ch.currentCharges < ch.maxCharges then
+        start    = ch.cooldownStartTime or start
+        duration = ch.cooldownDuration or duration
+        enabled  = 1
+        modRate  = ch.chargeModRate or modRate or 1
+      end
+    end
+  end
+
+  return start or 0, duration or 0, enabled or 0, modRate or 1, charges
+end
+
+local function UpdateSpellFrame(frame)
+  local data = frame.data
+  if not data or not data.spellID then return end
+
+  local iconID = GetSpellIcon(data.spellID)
+  frame.icon:SetTexture(iconID)
+  frame.icon:SetDesaturated(false)
+
+  if data.trackCooldown then
+    local start, duration, enabled, modRate = ReadCooldown(data.spellID)
+
+    if enabled == 1 and start > 0 and duration > 1.45 then
+      CooldownFrame_Set(frame.cooldown, start, duration, true)
+      frame._cooldownEnd = start + (duration / (modRate or 1))
+      frame.cooldownText:Show()
+      frame.icon:SetDesaturated(true)
+    else
+      CooldownFrame_Clear(frame.cooldown)
+      frame._cooldownEnd = nil
+      frame.cooldownText:Hide()
+      frame.icon:SetDesaturated(false)
+    end
+  else
+    CooldownFrame_Clear(frame.cooldown)
+    frame._cooldownEnd = nil
+    frame.cooldownText:Hide()
+    frame.icon:SetDesaturated(false)
+  end
+
+  if data.countFromAura and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID then
+    local aura = C_UnitAuras.GetPlayerAuraBySpellID(data.countFromAura)
+    local stacks = (aura and aura.applications) or 0
+    if stacks > 0 then
+      frame.count:SetText(stacks)
+      frame.count:Show()
+    else
+      frame.count:SetText("")
+      frame.count:Hide()
+    end
+  else
+    frame.count:SetText("")
+    frame.count:Hide()
+  end
+
+  if data.auraGlow and C_UnitAuras and C_UnitAuras.GetPlayerAuraBySpellID then
+    local aura = C_UnitAuras.GetPlayerAuraBySpellID(data.auraGlow)
+    if aura then
+      ActionButtonSpellAlertManager:ShowAlert(frame)
+      frame.isGlowing = true
+      if aura.icon then
+        frame.icon:SetTexture(aura.icon)
+      end
+    elseif frame.isGlowing then
+      ActionButtonSpellAlertManager:HideAlert(frame)
+      frame.isGlowing = false
+      frame.icon:SetTexture(GetSpellIcon(data.spellID))
+    end
+  end
+end
+
+function addon:UpdateAllFrames()
+  for _, f in ipairs(activeFrames) do UpdateSpellFrame(f) end
+end
+
+function addon:BuildFramesForSpec()
+  for _, f in ipairs(activeFrames) do f:Hide() end
+  wipe(activeFrames)
+
+  local specIndex = GetSpecialization()
+  local specID = specIndex and GetSpecializationInfo(specIndex) or 0
+
+  local top = self.db.profile.topBarSpells[specID]
+  if top then
+    local frames = {}
+    for _, data in ipairs(top) do
+      if C_SpellBook.IsSpellKnown(data.spellID) or C_SpellBook.IsSpellInSpellBook(data.spellID) then
+        local frame = CreateSpellFrame(data, #activeFrames + 1)
+        table.insert(frames, frame)
+        table.insert(activeFrames, frame)
+      end
+    end
+    LayoutTopBarSpells(frames)
+  end
+
+  local left = self.db.profile.leftBarSpells[specID]
+  if left then
+    local frames = {}
+    for _, data in ipairs(left) do
+      if C_SpellBook.IsSpellKnown(data.spellID) or C_SpellBook.IsSpellInSpellBook(data.spellID) then
+        local frame = CreateSpellFrame(data, #activeFrames + 1)
+        table.insert(frames, frame)
+        table.insert(activeFrames, frame)
+      end
+    end
+    LayoutSideBarSpells(frames, "LEFT")
+  end
+
+  local right = self.db.profile.rightBarSpells[specID]
+  if right then
+    local frames = {}
+    for _, data in ipairs(right) do
+      if C_SpellBook.IsSpellKnown(data.spellID) or C_SpellBook.IsSpellInSpellBook(data.spellID) then
+        local frame = CreateSpellFrame(data, #activeFrames + 1)
+        table.insert(frames, frame)
+        table.insert(activeFrames, frame)
+      end
+    end
+    LayoutSideBarSpells(frames, "RIGHT")
+  end
+
+  local bottom = self.db.profile.bottomBarSpells[specID]
+  if bottom then
+    local frames = {}
+    for _, data in ipairs(bottom) do
+      if C_SpellBook.IsSpellKnown(data.spellID) or C_SpellBook.IsSpellInSpellBook(data.spellID) then
+        local frame = CreateSpellFrame(data, #activeFrames + 1)
+        table.insert(frames, frame)
+        table.insert(activeFrames, frame)
+      end
+    end
+    LayoutBottomBarSpells(frames)
+  end
+
+  self:UpdateAllFrames()
+end


### PR DESCRIPTION
## Summary
- expose shared addon state and utilities in `ClassHUD.lua`
- move bar creation, layout, and cast handling into `ClassHUD_Bars.lua`
- add `ClassHUD_Classbar.lua` for class power segments and `ClassHUD_Spells.lua` for spell icon logic

## Testing
- not run (WoW API unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c886a73d308321ae6869a1c36ace3d