### PR TITLE
Refactor snapshot usage and streamline options

### DIFF
--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -321,7 +321,6 @@ function ClassHUD:RegisterOptions()
   local ACR = LibStub("AceConfigRegistry-3.0", true)
   local ACD = LibStub("AceConfigDialog-3.0", true)
   if not (ACR and ACD) then
-    print("|cff00ff88ClassHUD|r: AceConfig libs missing.")
     return false
   end
 
@@ -331,21 +330,13 @@ function ClassHUD:RegisterOptions()
 
   if type(builder) == "function" then
     local ok, res = pcall(builder, self)
-    if not ok then
-      print("|cff00ff88ClassHUD|r: BuildOptions error:", res)
-    else
+    if ok then
       opts = res
     end
   end
 
   -- If still missing, warn ONCE and install a tiny fallback so /chud works
   if not opts then
-    if not self._opts_missing_warned then
-      self._opts_missing_warned = true
-      print("|cff00ff88ClassHUD|r: ClassHUD_BuildOptions is missing. Using fallback options panel.")
-      print(
-        "|cff00ff88ClassHUD|r: Make sure ClassHUD_Options.lua is in the TOC, loads, and defines *global* function ClassHUD_BuildOptions(addon).")
-    end
     opts = {
       type = "group",
       name = "ClassHUD (fallback)",
@@ -390,7 +381,6 @@ function ClassHUD:OpenOptions()
   local ACR = LibStub("AceConfigRegistry-3.0", true)
   local ACD = LibStub("AceConfigDialog-3.0", true)
   if not (ACR and ACD) then
-    print("|cff00ff88ClassHUD|r: AceConfig libs missing.")
     return
   end
   if not ACR:GetOptionsTable("ClassHUD") then

--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -115,11 +115,6 @@ local defaults = {
       power    = 14,
     },
 
-    icons            = {
-      perRow  = 8,
-      spacing = 4,
-    },
-
     sideBars         = {
       size    = 36,
       spacing = 4,
@@ -150,12 +145,6 @@ local defaults = {
     -- =========================
     -- Spell & Buff persistence
     -- =========================
-
-    -- Brukerdefinerte tracked spells per bar
-    topBarSpells     = {},
-    leftBarSpells    = {},
-    rightBarSpells   = {},
-    bottomBarSpells  = {},
 
     -- Utility placement per spellID
     utilityPlacement = {
@@ -248,28 +237,25 @@ function ClassHUD:FullUpdate()
   if self.UpdateSpecialPower then self:UpdateSpecialPower() end
 end
 
--- ==================================================
--- CDM Snapshot Updater
--- ==================================================
+---Rebuilds the Cooldown Viewer snapshot for the current class/spec.
+---The snapshot is the authoritative data source for layout, options and UI.
 function ClassHUD:UpdateCDMSnapshot()
-  if not C_CooldownViewer or not C_CooldownViewer.IsCooldownViewerAvailable
-      or not C_CooldownViewer.IsCooldownViewerAvailable() then
-    return
-  end
+  if not self:IsCooldownViewerAvailable() then return end
 
-  local _, class                             = UnitClass("player")
-  local specID                               = GetSpecializationInfo(GetSpecialization() or 0)
+  local class, specID = self:GetPlayerClassSpec()
+  local snapshot = self:GetSnapshotForSpec(class, specID, true)
+  if not snapshot then return end
 
-  self.db.profile.cdmSnapshot                = self.db.profile.cdmSnapshot or {}
-  self.db.profile.cdmSnapshot[class]         = self.db.profile.cdmSnapshot[class] or {}
-  self.db.profile.cdmSnapshot[class][specID] = self.db.profile.cdmSnapshot[class][specID] or {}
+  for key in pairs(snapshot) do snapshot[key] = nil end
 
-  local categories                           = {
+  local categories = {
     [Enum.CooldownViewerCategory.Essential]   = "essential",
     [Enum.CooldownViewerCategory.Utility]     = "utility",
     [Enum.CooldownViewerCategory.TrackedBuff] = "buff",
     [Enum.CooldownViewerCategory.TrackedBar]  = "bar",
   }
+
+  local orderByCategory = {}
 
   for cat, catName in pairs(categories) do
     local ids = C_CooldownViewer.GetCooldownViewerCategorySet(cat)
@@ -279,21 +265,42 @@ function ClassHUD:UpdateCDMSnapshot()
         local sid = raw and (raw.spellID or raw.overrideSpellID or (raw.linkedSpellIDs and raw.linkedSpellIDs[1]))
         if sid then
           local info = C_Spell.GetSpellInfo(sid)
-          if info then
-            self.db.profile.cdmSnapshot[class][specID][sid] = {
-              spellID  = sid,
-              name     = info.name,
-              iconID   = info.iconID,
-              desc     = C_Spell.GetSpellDescription(sid),
-              category = catName,
+          local desc = C_Spell.GetSpellDescription(sid)
+
+          local entry = snapshot[sid]
+          if not entry then
+            entry = {
+              spellID     = sid,
+              name        = info and info.name or ("Spell " .. sid),
+              iconID      = info and info.iconID,
+              desc        = desc,
+              categories  = {},
+              category    = catName,
+              lastUpdated = GetServerTime and GetServerTime() or time(),
             }
+            snapshot[sid] = entry
+          else
+            entry.name        = info and info.name or entry.name
+            entry.iconID      = info and info.iconID or entry.iconID
+            entry.desc        = desc or entry.desc
+            entry.category    = entry.category or catName
+            entry.lastUpdated = GetServerTime and GetServerTime() or time()
           end
+
+          orderByCategory[catName] = (orderByCategory[catName] or 0) + 1
+          entry.categories[catName] = {
+            cooldownID      = cooldownID,
+            overrideSpellID = raw.overrideSpellID,
+            linkedSpellIDs  = raw.linkedSpellIDs and { table.unpack(raw.linkedSpellIDs) } or nil,
+            hasAura         = raw.hasAura,
+            order           = orderByCategory[catName],
+          }
         end
       end
     end
   end
 
-  print("|cff00ff88ClassHUD|r CDM snapshot oppdatert for", class, specID)
+  print(string.format("|cff00ff88ClassHUD|r Cooldown snapshot updated for %s spec %d", class, specID))
 end
 
 -- ===== Options bootstrap (registers with AceConfigRegistry directly) =====
@@ -538,25 +545,17 @@ SlashCmdList.CHUDLISTBUFFS = function()
     return
   end
 
-  local buffIDs = C_CooldownViewer.GetCooldownViewerCategorySet(enum.TrackedBuff)
-  if type(buffIDs) ~= "table" or #buffIDs == 0 then
-    print("|cff00ff88ClassHUD|r Ingen tracked buffs rapportert fra CDM.")
+  local class, specID = ClassHUD:GetPlayerClassSpec()
+  local snapshot = ClassHUD:GetSnapshotForSpec(class, specID, false)
+  if not snapshot then
+    print("|cff00ff88ClassHUD|r Ingen snapshot tilgjengelig. Bruk /classhudreset eller relogg.")
     return
   end
 
-  print("|cff00ff88ClassHUD|r Liste over Tracked Buffs fra CDM:")
-  for _, cooldownID in ipairs(buffIDs) do
-    local raw = C_CooldownViewer.GetCooldownViewerCooldownInfo(cooldownID)
-    if raw then
-      local sid = raw.spellID or raw.overrideSpellID
-      local name = sid and C_Spell.GetSpellName(sid) or "Unknown"
-      print(string.format("  SpellID=%d, Name=%s, hasAura=%s, override=%s, linked=%s",
-        sid or 0,
-        name,
-        tostring(raw.hasAura),
-        tostring(raw.overrideSpellID),
-        raw.linkedSpellIDs and table.concat(raw.linkedSpellIDs, ", ") or "nil"
-      ))
+  print("|cff00ff88ClassHUD|r Liste over Tracked Buffs fra snapshot:")
+  for spellID, data in pairs(snapshot) do
+    if data.categories and data.categories.buff then
+      print(string.format("  SpellID=%d, Name=%s", spellID, data.name or "Unknown"))
     end
   end
 end
@@ -572,20 +571,18 @@ SlashCmdList.CHUDBUFFDESC = function()
     return
   end
 
-  local buffIDs = C_CooldownViewer.GetCooldownViewerCategorySet(enum.TrackedBuff)
-  if type(buffIDs) ~= "table" or #buffIDs == 0 then
-    print("|cff00ff88ClassHUD|r Ingen tracked buffs rapportert fra CDM.")
+  local class, specID = ClassHUD:GetPlayerClassSpec()
+  local snapshot = ClassHUD:GetSnapshotForSpec(class, specID, false)
+  if not snapshot then
+    print("|cff00ff88ClassHUD|r Ingen snapshot tilgjengelig.")
     return
   end
 
   print("|cff00ff88ClassHUD|r Tracked Buff descriptions:")
-  for _, cooldownID in ipairs(buffIDs) do
-    local raw = C_CooldownViewer.GetCooldownViewerCooldownInfo(cooldownID)
-    if raw then
-      local sid = raw.spellID or raw.overrideSpellID
-      local name = sid and C_Spell.GetSpellName(sid) or "Unknown"
-      local desc = sid and C_Spell.GetSpellDescription(sid) or "No description"
-      print(string.format("  [%d] %s → %s", sid or 0, name, desc:gsub("\n", " ")))
+  for spellID, entry in pairs(snapshot) do
+    if entry.categories and entry.categories.buff then
+      local desc = entry.desc or C_Spell.GetSpellDescription(spellID) or "No description"
+      print(string.format("  [%d] %s → %s", spellID, entry.name or "Unknown", desc:gsub("\n", " ")))
     end
   end
 end
@@ -611,14 +608,11 @@ end
 -- ==================================================
 SLASH_CHUDTRACKED1 = "/chudtracked"
 SlashCmdList.CHUDTRACKED = function()
-  local _, class = UnitClass("player")
-  local specID   = GetSpecializationInfo(GetSpecialization() or 0)
+  local class, specID = ClassHUD:GetPlayerClassSpec()
 
   print("|cff00ff88ClassHUD|r Debug: Tracked Buffs for", class, specID)
 
-  local snapshot = ClassHUD.db.profile.cdmSnapshot
-      and ClassHUD.db.profile.cdmSnapshot[class]
-      and ClassHUD.db.profile.cdmSnapshot[class][specID]
+  local snapshot = ClassHUD:GetSnapshotForSpec(class, specID, false)
 
   local tracked = ClassHUD.db.profile.trackedBuffs
       and ClassHUD.db.profile.trackedBuffs[class]
@@ -630,13 +624,10 @@ SlashCmdList.CHUDTRACKED = function()
   end
 
   for buffID, data in pairs(snapshot) do
-    if data.category == "buff" then
+    if data.categories and data.categories.buff then
       local name = data.name or ("Buff " .. buffID)
       local active = false
-      local aura = C_UnitAuras.GetPlayerAuraBySpellID and C_UnitAuras.GetPlayerAuraBySpellID(buffID)
-      if not aura and UnitExists("pet") and C_UnitAuras and C_UnitAuras.GetAuraDataBySpellID then
-        aura = C_UnitAuras.GetAuraDataBySpellID("pet", buffID)
-      end
+      local aura = ClassHUD:GetAuraForSpell(buffID)
       if aura then active = true end
 
       local enabled = tracked and tracked[buffID] and "|cff00ff00ON|r" or "|cffff0000OFF|r"

--- a/ClassHUD.toc
+++ b/ClassHUD.toc
@@ -9,6 +9,7 @@
 ## OptionalDeps: LibSharedMedia-3.0
 
 ClassHUD.lua
+ClassHUD_Utils.lua
 ClassHUD_Bars.lua
 ClassHUD_Classbar.lua
 ClassHUD_Spells.lua

--- a/ClassHUD_Utils.lua
+++ b/ClassHUD_Utils.lua
@@ -1,0 +1,168 @@
+-- ClassHUD_Utils.lua
+-- Shared helper utilities used across the addon.
+
+---@type ClassHUD
+local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
+
+-- ---------------------------------------------------------------------------
+-- Profile helpers
+-- ---------------------------------------------------------------------------
+
+---Returns the player's class token ("MAGE", "PRIEST" ...) and specialization ID.
+---@return string classToken, number specID
+function ClassHUD:GetPlayerClassSpec()
+  local _, class = UnitClass("player")
+  local specIndex = GetSpecialization()
+  local specID = specIndex and GetSpecializationInfo(specIndex) or 0
+  return class, specID
+end
+
+---Internal helper to walk the saved variables profile tree.
+---@param create boolean|nil If true, missing tables are created on the way.
+---@param ... string Path within profile.
+---@return table|nil
+function ClassHUD:GetProfileTable(create, ...)
+  if not (self.db and self.db.profile) then return nil end
+
+  local node = self.db.profile
+  local path = { ... }
+
+  for i = 1, #path do
+    local key = path[i]
+    if type(node[key]) ~= "table" then
+      if not create then return nil end
+      node[key] = {}
+    end
+    node = node[key]
+  end
+
+  return node
+end
+
+---Convenience wrapper for accessing the cooldown snapshot storage.
+---@param create boolean|nil If true, the snapshot root is created if needed.
+---@return table|nil
+function ClassHUD:GetSnapshotRoot(create)
+  return self:GetProfileTable(create, "cdmSnapshot")
+end
+
+---Returns the snapshot table for a given class/spec combination.
+---@param class string|nil Defaults to the player's class.
+---@param specID number|nil Defaults to the player's current spec.
+---@param create boolean|nil Create the table if it does not exist.
+---@return table|nil
+function ClassHUD:GetSnapshotForSpec(class, specID, create)
+  local playerClass, playerSpec = self:GetPlayerClassSpec()
+  class = class or playerClass
+  specID = specID or playerSpec
+
+  local root = self:GetSnapshotRoot(create)
+  if not root then return nil end
+
+  if type(root[class]) ~= "table" then
+    if not create then return nil end
+    root[class] = {}
+  end
+
+  if type(root[class][specID]) ~= "table" then
+    if not create then return nil end
+    root[class][specID] = {}
+  end
+
+  return root[class][specID]
+end
+
+---Resets the snapshot table for the given class/spec.
+---@param class string|nil
+---@param specID number|nil
+function ClassHUD:ResetSnapshotFor(class, specID)
+  local snapshot = self:GetSnapshotForSpec(class, specID, true)
+  if not snapshot then return end
+  for k in pairs(snapshot) do
+    snapshot[k] = nil
+  end
+end
+
+---Returns the stored snapshot entry for a spell/buff ID.
+---@param spellID number
+---@param class string|nil
+---@param specID number|nil
+---@return table|nil
+function ClassHUD:GetSnapshotEntry(spellID, class, specID)
+  local snapshot = self:GetSnapshotForSpec(class, specID, false)
+  if not snapshot then return nil end
+  return snapshot[spellID]
+end
+
+---Iterates over snapshot entries for a given category and calls the handler.
+---@param category string One of "essential", "utility", "buff", "bar".
+---@param handler fun(spellID:number, entry:table, categoryData:table)
+---@param class string|nil
+---@param specID number|nil
+function ClassHUD:ForEachSnapshotEntry(category, handler, class, specID)
+  local snapshot = self:GetSnapshotForSpec(class, specID, false)
+  if not snapshot then return end
+
+  for spellID, entry in pairs(snapshot) do
+    local categories = entry.categories
+    local categoryData = categories and categories[category]
+    if categoryData then
+      handler(spellID, entry, categoryData)
+    end
+  end
+end
+
+---Checks if the Blizzard Cooldown Viewer API is currently available.
+---@return boolean
+function ClassHUD:IsCooldownViewerAvailable()
+  return C_CooldownViewer and C_CooldownViewer.IsCooldownViewerAvailable
+      and C_CooldownViewer.IsCooldownViewerAvailable()
+end
+
+-- ---------------------------------------------------------------------------
+-- Generic helpers
+-- ---------------------------------------------------------------------------
+
+---Formats a duration in seconds for compact cooldown text.
+---@param seconds number
+---@return string
+function ClassHUD.FormatSeconds(seconds)
+  if seconds >= 60 then
+    return string.format("%dm", math.ceil(seconds / 60))
+  elseif seconds >= 10 then
+    return tostring(math.floor(seconds + 0.5))
+  else
+    return string.format("%.1f", seconds)
+  end
+end
+
+local DEFAULT_AURA_UNITS = { "player", "pet", "target", "focus", "mouseover" }
+
+---Finds the first relevant aura for the given spell ID across a list of units.
+---@param spellID number
+---@param units string[]|nil
+---@return table|nil auraData, string|nil unit
+function ClassHUD:GetAuraForSpell(spellID, units)
+  if not C_UnitAuras then return nil end
+
+  units = units or DEFAULT_AURA_UNITS
+
+  if C_UnitAuras.GetPlayerAuraBySpellID then
+    local aura = C_UnitAuras.GetPlayerAuraBySpellID(spellID)
+    if aura then return aura, "player" end
+  end
+
+  if C_UnitAuras.GetAuraDataBySpellID then
+    for _, unit in ipairs(units) do
+      if unit ~= "player" and UnitExists(unit) then
+        local aura = C_UnitAuras.GetAuraDataBySpellID(unit, spellID)
+        if aura and (aura.isFromPlayer or aura.sourceUnit == "player" or aura.sourceUnit == "pet") then
+          return aura, unit
+        end
+      end
+    end
+  end
+
+  return nil
+end
+

--- a/ClassHUD_Utils.lua
+++ b/ClassHUD_Utils.lua
@@ -4,6 +4,8 @@
 ---@type ClassHUD
 local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
 
+ClassHUD._lastSpecID = ClassHUD._lastSpecID or 0
+
 -- ---------------------------------------------------------------------------
 -- Profile helpers
 -- ---------------------------------------------------------------------------
@@ -13,7 +15,18 @@ local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
 function ClassHUD:GetPlayerClassSpec()
   local _, class = UnitClass("player")
   local specIndex = GetSpecialization()
-  local specID = specIndex and GetSpecializationInfo(specIndex) or 0
+  local specID = 0
+
+  if specIndex then
+    specID = GetSpecializationInfo(specIndex) or 0
+  end
+
+  if specID and specID > 0 then
+    self._lastSpecID = specID
+  elseif self._lastSpecID and self._lastSpecID > 0 then
+    specID = self._lastSpecID
+  end
+
   return class, specID
 end
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Built with [Ace3](https://www.wowace.com/projects/ace3) and LibSharedMedia.
 
 ## ✨ Features
 
-- Cast, HP, Resource, and Special Power bars.
-- Customizable top/bottom/left/right bars for spells.
-- Spell tracking with cooldowns, aura glow, and stack counts.
-- Suggested spells per class/spec (pre-filled).
-- Ace3 options panel (`/chud`).
+- Cast, HP, primary resource, and special power bars that adapt per class/spec.
+- Snapshot-driven spell layout sourced from Blizzard's Cooldown Viewer API.
+- Automatic glow, cooldown, and aura stack handling for tracked spells and buffs.
+- Configurable utility placement (top/bottom/left/right) with per-spec persistence.
+- Simplified Ace3 options panel (`/chud`) with snapshot refresh, tracked buff toggles, and buff→spell link editing.
 
 ---
 
@@ -26,16 +26,39 @@ Built with [Ace3](https://www.wowace.com/projects/ace3) and LibSharedMedia.
 
 ## 🛠 Usage
 
-- Open options with `/chud`
-- Add spells manually by SpellID or from suggested list
-- Supports aura glow, aura stack counts, and icon swap on aura active
-- Fully movable and resizable bars
+- Open options with `/chud`.
+- Refresh the Blizzard snapshot (if needed) from **Snapshot → Refresh Snapshot**.
+- Configure which utility cooldowns appear on each bar under **Spells & Buffs → Utility Placement**.
+- Toggle tracked buffs and manage buff links under **Spells & Buffs**.
+- Move the anchor by unlocking the frame in **General**.
+
+## 🗂 Architecture
+
+The addon is organised into lightweight modules:
+
+| File | Responsibility |
+| ---- | -------------- |
+| `ClassHUD.lua` | Core addon lifecycle, events, saved variables, snapshot management. |
+| `ClassHUD_Utils.lua` | Shared helpers for profile access, snapshot lookup, formatting, and aura search. |
+| `ClassHUD_Bars.lua` | Anchor frame creation, cast/resource/health bar layout and updates. |
+| `ClassHUD_Classbar.lua` | Class-specific special power/segment handling. |
+| `ClassHUD_Spells.lua` | Snapshot-driven spell frame creation, cooldown/aura updates, tracked buff bar. |
+| `ClassHUD_Options.lua` | Ace3 configuration rebuilt around the snapshot cache. |
+| `ClassHUD_SpellSuggestions.lua` | Optional pre-filled spell suggestions (data only). |
+
+### Suggested future structure
+
+To keep modules focused as the addon grows, consider grouping files under folders:
+
+- `core/` for bootstrap (`ClassHUD.lua`, `ClassHUD_Utils.lua`).
+- `ui/` for bars, spell frames, and any future UI widgets.
+- `config/` for options and suggestion data.
+- `modules/` for optional trackers (e.g., interrupt tracker, class-specific extras).
 
 ## 🦴 Todo
 
-- [ ] - Clean up the Options. Better the flow
-- [ ] - Add sound notification
-- [ ] - Add more classes
+- [ ] Add optional sound notifications.
+- [ ] Extend spell suggestions for remaining specs.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a shared utils module and refactor snapshot handling to be the primary data source
- rebuild spell frame logic and tracked buff handling around the cached snapshot
- replace the Ace3 options with a snapshot-driven panel and document the refreshed architecture

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbdea078f4832182701738377c52a4