### PR TITLE
Add tracked bar support to tracked HUD systems

### DIFF
--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -640,9 +640,9 @@ SlashCmdList.CHUDTRACKED = function()
   for buffID, data in pairs(snapshot) do
     if data.categories and data.categories.buff then
       local name = data.name or ("Buff " .. buffID)
-      local active = false
-      local aura = ClassHUD:GetAuraForSpell(buffID)
-      if aura then active = true end
+      local candidates = ClassHUD:GetAuraCandidatesForEntry(data, buffID)
+      local aura = select(1, ClassHUD:FindAuraFromCandidates(candidates, { "player", "pet" }))
+      local active = aura and true or false
 
       local config = tracked and ClassHUD.GetTrackedEntryConfig
           and ClassHUD:GetTrackedEntryConfig(class, specID, buffID, false)

--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -511,7 +511,7 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
   end
 
   -- Spells (auras + cooldowns)
-  if (event == "UNIT_AURA" and unit == "player") or
+  if (event == "UNIT_AURA" and (unit == "player" or unit == "pet")) or
       event == "SPELL_UPDATE_COOLDOWN" or event == "SPELL_UPDATE_CHARGES" or event == "UNIT_SPELLCAST_SUCCEEDED" then
     if ClassHUD.UpdateAllFrames then ClassHUD:UpdateAllFrames() end
     -- Also show instant-cast fake bar if bars module hooked SUCCEEDED

--- a/ClassHUD.toc
+++ b/ClassHUD.toc
@@ -9,6 +9,7 @@
 ## OptionalDeps: LibSharedMedia-3.0
 
 ClassHUD.lua
+ClassHUD_Utils.lua
 ClassHUD_Bars.lua
 ClassHUD_Classbar.lua
 ClassHUD_Spells.lua

--- a/ClassHUD_Bars.lua
+++ b/ClassHUD_Bars.lua
@@ -97,6 +97,7 @@ function ClassHUD:Layout()
   end
 
   local trackedContainer = UI.trackedContainer
+  UI.tracked = trackedContainer
   trackedContainer:SetParent(UI.anchor)
   trackedContainer:ClearAllPoints()
   trackedContainer:SetPoint("TOPLEFT", UI.anchor, "TOPLEFT", 0, 0)

--- a/ClassHUD_Bars.lua
+++ b/ClassHUD_Bars.lua
@@ -91,59 +91,65 @@ function ClassHUD:Layout()
     return UI.attachments[name]
   end
 
-  local y = 0
-
-  -- Cast (top)
-  if self.db.profile.show.cast then
-    UI.cast:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
-    UI.cast:SetWidth(w)
-    UI.cast:SetHeight(self.db.profile.height.cast)
-    y = y + UI.cast:GetHeight() + gap
-  else
-    UI.cast:ClearAllPoints(); UI.cast:Hide()
+  if not UI.trackedContainer then
+    UI.trackedContainer = CreateFrame("Frame", "ClassHUDTrackedContainer", UI.anchor, "BackdropTemplate")
+    UI.trackedContainer:SetSize(w, 0)
   end
 
-  -- HP
-  if self.db.profile.show.hp then
-    UI.hp:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
-    UI.hp:SetWidth(w)
-    UI.hp:SetHeight(self.db.profile.height.hp)
-    y = y + UI.hp:GetHeight() + gap
+  local trackedContainer = UI.trackedContainer
+  trackedContainer:SetParent(UI.anchor)
+  trackedContainer:ClearAllPoints()
+  trackedContainer:SetPoint("TOPLEFT", UI.anchor, "TOPLEFT", 0, 0)
+  trackedContainer:SetPoint("TOPRIGHT", UI.anchor, "TOPRIGHT", 0, 0)
+  trackedContainer:SetWidth(w)
+
+  if not self.db.profile.show.buffs then
+    trackedContainer:SetHeight(0)
+    trackedContainer:Hide()
   else
-    UI.hp:ClearAllPoints(); UI.hp:Hide()
+    trackedContainer:Show()
   end
 
-  -- Primary resource
-  if self.db.profile.show.resource then
-    UI.resource:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
-    UI.resource:SetWidth(w)
-    UI.resource:SetHeight(self.db.profile.height.resource)
-    y = y + UI.resource:GetHeight() + gap
-  else
-    UI.resource:ClearAllPoints(); UI.resource:Hide()
+  local trackedHeight = trackedContainer:GetHeight() or 0
+  if trackedHeight < 0 then trackedHeight = 0 end
+
+  local previous = trackedContainer
+  local offset = (trackedHeight > 0 and gap) or 0
+
+  local function anchorBar(frame, enabled, height)
+    if not frame then return end
+
+    frame:ClearAllPoints()
+    if enabled then
+      frame:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, -offset)
+      frame:SetPoint("TOPRIGHT", previous, "BOTTOMRIGHT", 0, -offset)
+      frame:SetWidth(w)
+      frame:SetHeight(height)
+      frame:Show()
+      previous = frame
+      offset = gap
+    else
+      frame:Hide()
+    end
   end
 
-  -- Special power container
-  if self.db.profile.show.power then
-    UI.power:SetPoint("TOP", UI.anchor, "TOP", 0, -y)
-    UI.power:SetWidth(w)
-    UI.power:SetHeight(self.db.profile.height.power)
-  else
-    UI.power:ClearAllPoints(); UI.power:Hide()
-  end
+  anchorBar(UI.cast, self.db.profile.show.cast, self.db.profile.height.cast)
+  anchorBar(UI.hp, self.db.profile.show.hp, self.db.profile.height.hp)
+  anchorBar(UI.resource, self.db.profile.show.resource, self.db.profile.height.resource)
+  anchorBar(UI.power, self.db.profile.show.power, self.db.profile.height.power)
 
   -- Update attachment points for spell icon layout
   local top = ensure("TOP")
   top:ClearAllPoints()
-  top:SetPoint("BOTTOMLEFT", UI.cast, "TOPLEFT", 0, 0)
-  top:SetPoint("BOTTOMRIGHT", UI.cast, "TOPRIGHT", 0, 0)
+  top:SetPoint("BOTTOMLEFT", trackedContainer, "TOPLEFT", 0, 0)
+  top:SetPoint("BOTTOMRIGHT", trackedContainer, "TOPRIGHT", 0, 0)
   top:SetHeight(1)
 
   -- BOTTOM: 1px strip aligned to bottom of power
   local bottom = ensure("BOTTOM")
   bottom:ClearAllPoints()
-  bottom:SetPoint("TOPLEFT", UI.power, "BOTTOMLEFT", 0, 0)
-  bottom:SetPoint("TOPRIGHT", UI.power, "BOTTOMRIGHT", 0, 0)
+  bottom:SetPoint("TOPLEFT", previous, "BOTTOMLEFT", 0, 0)
+  bottom:SetPoint("TOPRIGHT", previous, "BOTTOMRIGHT", 0, 0)
   bottom:SetHeight(1)
 
   -- LEFT/RIGHT

--- a/ClassHUD_Bars.lua
+++ b/ClassHUD_Bars.lua
@@ -108,7 +108,12 @@ function ClassHUD:Layout()
     trackedContainer:SetHeight(0)
     trackedContainer:Hide()
   else
-    trackedContainer:Show()
+    local height = trackedContainer:GetHeight() or 0
+    if height > 0 then
+      trackedContainer:Show()
+    else
+      trackedContainer:Hide()
+    end
   end
 
   local trackedHeight = trackedContainer:GetHeight() or 0
@@ -142,8 +147,8 @@ function ClassHUD:Layout()
   -- Update attachment points for spell icon layout
   local top = ensure("TOP")
   top:ClearAllPoints()
-  top:SetPoint("BOTTOMLEFT", trackedContainer, "TOPLEFT", 0, 0)
-  top:SetPoint("BOTTOMRIGHT", trackedContainer, "TOPRIGHT", 0, 0)
+  top:SetPoint("TOPLEFT", trackedContainer, "BOTTOMLEFT", 0, 0)
+  top:SetPoint("TOPRIGHT", trackedContainer, "BOTTOMRIGHT", 0, 0)
   top:SetHeight(1)
 
   -- BOTTOM: 1px strip aligned to bottom of power

--- a/ClassHUD_Bars.lua
+++ b/ClassHUD_Bars.lua
@@ -119,8 +119,16 @@ function ClassHUD:Layout()
   local trackedHeight = trackedContainer:GetHeight() or 0
   if trackedHeight < 0 then trackedHeight = 0 end
 
+  local topBarFrame = UI.topBarFrame
+  local topBarHeight = topBarFrame and topBarFrame:GetHeight() or 0
+
   local previous = trackedContainer
   local offset = (trackedHeight > 0 and gap) or 0
+
+  if topBarFrame and topBarHeight and topBarHeight > 0 then
+    previous = topBarFrame
+    offset = gap
+  end
 
   local function anchorBar(frame, enabled, height)
     if not frame then return end

--- a/ClassHUD_Bars.lua
+++ b/ClassHUD_Bars.lua
@@ -101,7 +101,7 @@ function ClassHUD:Layout()
   local containers = {
     TRACKED_ICONS = ensure("TRACKED_ICONS"),
     TOP           = ensure("TOP"),
-    TRACKED_BARS  = ensure("TRACKED_BARS"),
+    -- TRACKED_BARS  = ensure("TRACKED_BARS"),
     CAST          = ensure("CAST"),
     HP            = ensure("HP"),
     RESOURCE      = ensure("RESOURCE"),
@@ -133,7 +133,9 @@ function ClassHUD:Layout()
     end
   end
 
-  layoutStatusBar(UI.cast, "CAST", self.db.profile.show.cast, self.db.profile.height.cast)
+  if UI.cast and UI.cast:IsShown() then
+    layoutStatusBar(UI.cast, "CAST", true, self.db.profile.height.cast)
+  end
   layoutStatusBar(UI.hp, "HP", self.db.profile.show.hp, self.db.profile.height.hp)
   layoutStatusBar(UI.resource, "RESOURCE", self.db.profile.show.resource, self.db.profile.height.resource)
 
@@ -161,7 +163,7 @@ function ClassHUD:Layout()
   local order = {
     "TRACKED_ICONS",
     "TOP",
-    "TRACKED_BARS",
+    -- "TRACKED_BARS",
     "CAST",
     "HP",
     "RESOURCE",

--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -217,23 +217,23 @@ local function BuildTrackedBuffArgs(addon, container)
             NotifyOptionsChanged()
           end,
         },
-        showBar = {
-          type = "toggle",
-          name = "Show as Bar",
-          order = 2,
-          disabled = not data.hasBar,
-          get = function()
-            local cfg = getConfig(false)
-            return cfg and cfg.showBar or false
-          end,
-          set = function(_, value)
-            local cfg = getConfig(true)
-            cfg.showBar = not not value
-            addon:BuildTrackedBuffFrames()
-            BuildTrackedBuffArgs(addon, container)
-            NotifyOptionsChanged()
-          end,
-        },
+        -- showBar = {
+        --   type = "toggle",
+        --   name = "Show as Bar",
+        --   order = 2,
+        --   disabled = not data.hasBar,
+        --   get = function()
+        --     local cfg = getConfig(false)
+        --     return cfg and cfg.showBar or false
+        --   end,
+        --   set = function(_, value)
+        --     local cfg = getConfig(true)
+        --     cfg.showBar = not not value
+        --     addon:BuildTrackedBuffFrames()
+        --     BuildTrackedBuffArgs(addon, container)
+        --     NotifyOptionsChanged()
+        --   end,
+        -- },
         barShowIcon = {
           type = "toggle",
           name = "Show Icon",
@@ -313,7 +313,8 @@ local function BuildBuffLinkArgs(addon, container)
   if not next(links) then
     container.empty = {
       type = "description",
-      name = "No manual links stored for this spec. They are created automatically when buffs reference spells in their description.",
+      name =
+      "No manual links stored for this spec. They are created automatically when buffs reference spells in their description.",
       order = order,
     }
     return
@@ -941,7 +942,8 @@ function ClassHUD_BuildOptions(addon)
                   if not spellID then return end
                   addon.db.profile.utilityPlacement[spellID] = "TOP"
                   addon:BuildFramesForSpec()
-                  BuildPlacementArgs(addon, topBarContainer, "essential", "TOP", "No essential spells reported for this spec.")
+                  BuildPlacementArgs(addon, topBarContainer, "essential", "TOP",
+                    "No essential spells reported for this spec.")
                   NotifyOptionsChanged()
                 end,
               },
@@ -1085,8 +1087,10 @@ function ClassHUD_BuildOptions(addon)
             func = function()
               addon:UpdateCDMSnapshot()
               addon:BuildFramesForSpec()
-              BuildPlacementArgs(addon, topBarContainer, "essential", "TOP", "No essential spells reported for this spec.")
-              BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN", "No utility cooldowns reported by the snapshot for this spec.")
+              BuildPlacementArgs(addon, topBarContainer, "essential", "TOP",
+                "No essential spells reported for this spec.")
+              BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN",
+                "No utility cooldowns reported by the snapshot for this spec.")
               BuildTrackedBuffArgs(addon, trackedContainer)
               BuildBuffLinkArgs(addon, linkContainer)
               NotifyOptionsChanged()
@@ -1095,7 +1099,8 @@ function ClassHUD_BuildOptions(addon)
           note = {
             type = "description",
             order = 2,
-            name = "The snapshot is rebuilt automatically on login and specialization changes. Use this button if Blizzard updates the Cooldown Viewer data while you are logged in.",
+            name =
+            "The snapshot is rebuilt automatically on login and specialization changes. Use this button if Blizzard updates the Cooldown Viewer data while you are logged in.",
           },
         },
       },
@@ -1103,7 +1108,8 @@ function ClassHUD_BuildOptions(addon)
   }
 
   BuildPlacementArgs(addon, topBarContainer, "essential", "TOP", "No essential spells reported for this spec.")
-  BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN", "No utility cooldowns reported by the snapshot for this spec.")
+  BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN",
+    "No utility cooldowns reported by the snapshot for this spec.")
   BuildTrackedBuffArgs(addon, trackedContainer)
   BuildBuffLinkArgs(addon, linkContainer)
 

--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -1,1372 +1,1107 @@
 -- ClassHUD_Options.lua
-function ClassHUD_BuildOptions(addon)
-  local db  = addon.db
-  local LSM = LibStub("LibSharedMedia-3.0", true)
-  LibStub("AceConfigDialog-3.0"):AddToBlizOptions("ClassHUD")
-  local ACR = LibStub("AceConfigRegistry-3.0")
-  local ACD = LibStub("AceConfigDialog-3.0")
+-- Rebuilt, snapshot-driven options UI
 
-  addon._opts = addon._opts -- behold om du allerede har satt den et annet sted
+---@type ClassHUD
+local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
 
-  local function ForceRefresh(barKey)
-    if ACR then ACR:NotifyChange("ClassHUD") end
-    if not ACD then return end
+local ACR = LibStub("AceConfigRegistry-3.0")
+local LSM = LibStub("LibSharedMedia-3.0", true)
 
-    local pathByKey = {
-      top    = { "topBar", "spells" },
-      bottom = { "bottomBar", "spells" },
-      left   = { "sidebars", "leftBar", "spells" },  -- 👈 updated
-      right  = { "sidebars", "rightBar", "spells" }, -- 👈 updated
+local PLACEMENTS = {
+  HIDDEN = "Hidden",
+  TOP = "Top Bar",
+  BOTTOM = "Bottom Bar",
+  LEFT = "Left Side",
+  RIGHT = "Right Side",
+}
+
+local optionsState = {
+  newLinkBuffID = "",
+  newLinkSpellID = "",
+}
+
+local function NotifyOptionsChanged()
+  if ACR then ACR:NotifyChange("ClassHUD") end
+end
+
+local function SortEntries(snapshot, category)
+  if not snapshot then return {} end
+  local list = {}
+  for spellID, entry in pairs(snapshot) do
+    local cat = entry.categories and entry.categories[category]
+    if cat then
+      table.insert(list, { spellID = spellID, entry = entry, order = (cat.order or math.huge) })
+    end
+  end
+  table.sort(list, function(a, b)
+    if a.order == b.order then
+      return (a.entry.name or "") < (b.entry.name or "")
+    end
+    return a.order < b.order
+  end)
+  return list
+end
+
+local function BuildPlacementArgs(addon, container, category, defaultPlacement, emptyText)
+  for k in pairs(container) do container[k] = nil end
+
+  addon.db.profile.utilityPlacement = addon.db.profile.utilityPlacement or {}
+  local placements = addon.db.profile.utilityPlacement
+  local snapshot = addon:GetSnapshotForSpec(nil, nil, false)
+  local list = SortEntries(snapshot, category)
+  local order = 1
+  local added = {}
+
+  local function addOption(spellID, entry)
+    added[spellID] = true
+
+    local iconID = entry and entry.iconID
+    local name = entry and entry.name
+
+    if not name then
+      local info = C_Spell.GetSpellInfo(spellID)
+      iconID = iconID or (info and info.iconID)
+      name = info and info.name or ("Spell " .. spellID)
+    end
+
+    local icon = iconID and ("|T" .. iconID .. ":16|t ") or ""
+
+    container["spell" .. spellID] = {
+      type = "select",
+      name = icon .. name .. " (" .. spellID .. ")",
+      order = order,
+      values = PLACEMENTS,
+      get = function()
+        return placements[spellID] or defaultPlacement
+      end,
+      set = function(_, value)
+        if value == defaultPlacement then
+          placements[spellID] = nil
+        else
+          placements[spellID] = value
+        end
+        addon:BuildFramesForSpec()
+        BuildPlacementArgs(addon, container, category, defaultPlacement, emptyText)
+        NotifyOptionsChanged()
+      end,
     }
-    local path = pathByKey[barKey]
-    if not path then return end
 
-    if ACD.OpenFrames and ACD.OpenFrames["ClassHUD"] then
-      ACD:SelectGroup("ClassHUD", unpack(path))
-    else
-      ACD:Open("ClassHUD")
-      ACD:SelectGroup("ClassHUD", unpack(path))
-    end
+    order = order + 1
   end
 
-  -- ===== Ensure defaults exist (same spirit as your original) =====
-  db.profile.textures        = db.profile.textures or { bar = "Blizzard", font = "Friz Quadrata TT" }
-  db.profile.show            = db.profile.show or { cast = true, hp = true, resource = true, power = true }
-  db.profile.height          = db.profile.height or { cast = 18, hp = 14, resource = 14, power = 14 }
-  db.profile.colors          = db.profile.colors or {
-    resource = { r = 0, g = 0.55, b = 1 },
-    power = { r = 1, g = 0.85, b = 0.1 },
-    resourceClass = true,
-  }
-  db.profile.icons           = db.profile.icons or { enabled = true, size = 36, spacing = 4 } -- (legacy, safe)
-  db.profile.position        = db.profile.position or { x = 0, y = -150 }
-
-  db.profile.topBar          = db.profile.topBar or {}
-  db.profile.bottomBar       = db.profile.bottomBar or {}
-  db.profile.sideBars        = db.profile.sideBars or {}
-  db.profile.topBarSpells    = db.profile.topBarSpells or {}
-  db.profile.bottomBarSpells = db.profile.bottomBarSpells or {}
-  db.profile.leftBarSpells   = db.profile.leftBarSpells or {}
-  db.profile.rightBarSpells  = db.profile.rightBarSpells or {}
-  -- ICON TEXT defaults
-  db.profile.iconText        = db.profile.iconText or {
-    count = { size = 14, color = { r = 1, g = 1, b = 1 }, point = "BOTTOMRIGHT", ofsX = -2, ofsY = 2 },
-    aura  = { enabled = false, size = 10, color = { r = 1, g = 0.8, b = 0.2 }, point = "TOPLEFT", ofsX = 2, ofsY = -2 },
-  }
-
-
-  local suggestedSpells = _G.ClassHUD_SpellSuggestions or {}
-
-  --------------------------------------------------------------------
-  -- Generic spell-tree rebuilder (works for top/bottom/left/right)
-  --------------------------------------------------------------------
-  local function GetSpellsContainer(opts, barKey)
-    if barKey == "left" then return opts.args.sidebars.args.leftBar.args.spells.args end
-    if barKey == "right" then return opts.args.sidebars.args.rightBar.args.spells.args end
-    return opts.args[barKey .. "Bar"].args.spells.args
+  for _, item in ipairs(list) do
+    addOption(item.spellID, item.entry)
   end
 
-  local function parseIDList(str)
-    local out = {}
-    if type(str) ~= "string" then return out end
-    for num in str:gmatch("%d+") do
-      local n = tonumber(num)
-      if n then table.insert(out, n) end
-    end
-    return out
-  end
-
-  local function joinIDList(tbl)
-    if type(tbl) ~= "table" then return "" end
-    local t = {}
-    for _, n in ipairs(tbl) do table.insert(t, tostring(n)) end
-    return table.concat(t, ", ")
-  end
-
-  local function auraIconsString(list)
-    local parts = {}
-    if type(list) == "table" then
-      for _, id in ipairs(list) do
-        local info = C_Spell.GetSpellInfo(id)
-        if info and info.iconID then
-          table.insert(parts, ("|T%d:18|t"):format(info.iconID))
-        end
+  if category == "essential" then
+    for spellID, placement in pairs(placements) do
+      if placement == "TOP" and not added[spellID] then
+        local entry = snapshot and snapshot[spellID]
+        addOption(spellID, entry)
       end
     end
-    if #parts == 0 then return "|cff888888(no auras added)|r" end
-    return table.concat(parts, "  ")
   end
 
-
-
-  local function RebuildSpellTree(opts, db, addon, barKey)
-    local specID = GetSpecializationInfo(GetSpecialization() or 0)
-    local spellsKey = barKey .. "BarSpells"
-    db.profile[spellsKey] = db.profile[spellsKey] or {}
-    db.profile[spellsKey][specID] = db.profile[spellsKey][specID] or {}
-
-    opts = opts or (addon and addon._opts)
-    if not opts then return end
-
-    local container = GetSpellsContainer(opts, barKey) -- 👈 viktig endring
-    -- wipe gamle noder
-    for k in pairs(container) do
-      if type(k) == "string" and k:match("^spell_") then container[k] = nil end
-    end
-
-    local list = db.profile[spellsKey][specID]
-    for i, data in ipairs(list) do
-      local idx = i
-      local info = C_Spell.GetSpellInfo(data.spellID)
-      local displayName = info and ("|T%d:16|t %s (%d)"):format(info.iconID, info.name, data.spellID)
-          or ("Unknown (" .. tostring(data.spellID) .. ")")
-
-      container["spell_" .. idx] = {
-        type   = "group",
-        name   = displayName,
-        inline = true,
-        order  = 100 + idx,
-        args   = {
-          -- Rekkeflytting
-          rowHeader = { type = "header", name = "Row", order = 98 },
-          moveUp = {
-            type = "execute",
-            name = "Move Up",
-            order = 98.1,
-            disabled = function() return idx == 1 end,
-            func = function()
-              if idx > 1 then
-                list[idx], list[idx - 1] = list[idx - 1], list[idx]
-                addon:BuildFramesForSpec()
-                RebuildSpellTree(opts, db, addon, barKey)
-                ACR:NotifyChange("ClassHUD")
-              end
-            end,
-          },
-          moveDown = {
-            type = "execute",
-            name = "Move Down",
-            order = 98.2,
-            disabled = function() return idx == #list end,
-            func = function()
-              if idx < #list then
-                list[idx], list[idx + 1] = list[idx + 1], list[idx]
-                addon:BuildFramesForSpec()
-                RebuildSpellTree(opts, db, addon, barKey)
-                ACR:NotifyChange("ClassHUD")
-              end
-            end,
-          },
-          trackCooldown = {
-            type = "toggle",
-            name = "Track Cooldown",
-            order = 1,
-            get = function() return not not data.trackCooldown end,
-            set = function(_, v)
-              data.trackCooldown = v; addon:BuildFramesForSpec()
-            end,
-          },
-          glowHeader = { type = "header", name = "Glow & Icon", order = 3 },
-          glowEnabled = {
-            type = "toggle",
-            name = "Enable Glow",
-            desc = "Show spell alert glow when any aura in the list is active on you.",
-            order = 3.1,
-            get = function() return data.glowEnabled ~= false end,
-            set = function(_, v)
-              data.glowEnabled = v; addon:BuildFramesForSpec()
-            end,
-          },
-          iconFromAura = {
-            type = "toggle",
-            name = "Use Aura Icon When Active",
-            desc = "When glowing, replace the spell icon with the matching aura's icon.",
-            order = 3.2,
-            get = function() return not not data.iconFromAura end,
-            set = function(_, v)
-              data.iconFromAura = v; addon:BuildFramesForSpec()
-            end,
-          },
-          countFromAura = {
-            type = "input",
-            name = "Aura SpellID for Stacks",
-            order = 2,
-            get = function() return data.countFromAura and tostring(data.countFromAura) or "" end,
-            set = function(_, v)
-              data.countFromAura = tonumber(v); addon:BuildFramesForSpec()
-            end,
-          },
-          countFromAuraUnit = {
-            type = "select",
-            name = "Count Aura Unit",
-            order = 2.1,
-            values = { player = "Player", pet = "Pet", target = "Target", focus = "Focus" },
-            get = function() return data.countFromAuraUnit or "player" end,
-            set = function(_, v)
-              data.countFromAuraUnit = v; addon:BuildFramesForSpec()
-            end,
-          },
-          auraGlowSingle = {
-            type = "input",
-            name = "Glow Aura (single ID, legacy)",
-            desc = "Optional legacy single-ID glow (kept for backward compatibility). Use the list below for multiple.",
-            order = 3,
-            get = function() return data.auraGlow and tostring(data.auraGlow) or "" end,
-            set = function(_, v)
-              data.auraGlow = tonumber(v)
-              addon:BuildFramesForSpec()
-              RebuildSpellTree(opts, db, addon, barKey)
-              LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-            end,
-          },
-          auraGlowList = {
-            type = "input",
-            name = "Glow Aura IDs (comma/space separated)",
-            order = 3.1,
-            width = "full",
-            get = function() return joinIDList(data.auraGlowList) end,
-            set = function(_, v)
-              data.auraGlowList = parseIDList(v)
-              addon:BuildFramesForSpec()
-              RebuildSpellTree(opts, db, addon, barKey)
-              LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-            end,
-          },
-          auraGlowListIcons = {
-            type = "description",
-            name = function() return "Current:  " .. auraIconsString(data.auraGlowList) end,
-            order = 3.5,
-            fontSize = "medium",
-          },
-          clearGlowList = {
-            type = "execute",
-            name = "Clear Glow List",
-            order = 3.6,
-            func = function()
-              data.auraGlowList = nil
-              addon:BuildFramesForSpec()
-              RebuildSpellTree(opts, db, addon, barKey)
-              LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-            end,
-          },
-          clearAuraGlow = {
-            type = "execute",
-            name = "Clear Aura Glow",
-            order = 4,
-            func = function()
-              data.auraGlow = nil; addon:BuildFramesForSpec()
-            end,
-          },
-          soundOnGlow = {
-            type = "select",
-            name = "Sound on Glow",
-            order = 4.5,
-            width = "normal",
-            values = function()
-              local t = { none = "(none)" }
-              local LSM = LibStub("LibSharedMedia-3.0", true)
-              if LSM then for k, _ in pairs(LSM:HashTable("sound")) do t[k] = k end end
-              return t
-            end,
-            get = function() return data.soundOnGlow or "none" end,
-            set = function(_, v) data.soundOnGlow = v end,
-          },
-          remove = {
-            type = "execute",
-            name = "Remove This Spell",
-            order = 99,
-            confirm = true,
-            confirmText = "Remove this spell?",
-            func = function()
-              table.remove(list, idx)
-              addon:BuildFramesForSpec()
-              RebuildSpellTree(opts, db, addon, barKey)
-              LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-            end,
-          },
-        },
-      }
-    end
+  if order == 1 then
+    container.empty = {
+      type = "description",
+      name = emptyText or "No entries available for this category.",
+      order = order,
+    }
   end
+end
 
+local function BuildTrackedBuffArgs(addon, container)
+  for k in pairs(container) do container[k] = nil end
 
-  local PLACEMENTS = {
-    HIDDEN = "Hidden",
-    TOP = "Top Bar",
-    BOTTOM = "Bottom Bar",
-    LEFT = "Left Bar",
-    RIGHT = "Right Bar",
-  }
+  local class, specID = addon:GetPlayerClassSpec()
+  local snapshot = addon:GetSnapshotForSpec(class, specID, false)
 
-  local function BuildUtilityOptions()
-    local args = {}
+  addon.db.profile.trackedBuffs[class] = addon.db.profile.trackedBuffs[class] or {}
+  addon.db.profile.trackedBuffs[class][specID] = addon.db.profile.trackedBuffs[class][specID] or {}
 
-    if not Enum or not Enum.CooldownViewerCategory then return args end
+  local tracked = addon.db.profile.trackedBuffs[class][specID]
 
-    local utilIDs = C_CooldownViewer.GetCooldownViewerCategorySet(Enum.CooldownViewerCategory.Utility)
-    if type(utilIDs) ~= "table" then return args end
+  local entries = {}
 
-    for _, cooldownID in ipairs(utilIDs) do
-      local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cooldownID)
-      if info and info.spellID then
-        local spellID = info.spellID
-        local spellInfo = C_Spell.GetSpellInfo(spellID)
-        if spellInfo then
-          local icon = spellInfo.iconID and ("|T" .. spellInfo.iconID .. ":16|t ") or ""
-          local name = spellInfo.name or ("Spell " .. spellID)
+  if snapshot then
+    for spellID, entry in pairs(snapshot) do
+      local categories = entry.categories
+      local hasBuff = categories and categories.buff
+      local hasBar = categories and categories.bar
+      if hasBuff or hasBar then
+        local order = math.huge
+        if hasBuff and hasBuff.order then order = math.min(order, hasBuff.order) end
+        if hasBar and hasBar.order then order = math.min(order, hasBar.order) end
 
-          args["spell_" .. spellID] = {
-            type = "select",
-            name = icon .. name .. " (" .. spellID .. ")",
-            values = PLACEMENTS,
-            get = function()
-              return ClassHUD.db.profile.utilityPlacement[spellID] or "HIDDEN"
-            end,
-            set = function(_, val)
-              ClassHUD.db.profile.utilityPlacement[spellID] = val
-              ClassHUD:BuildFramesForSpec() -- rebuild når brukeren endrer
-            end,
-            order = spellID,
-          }
-        end
-      end
-    end
+        local icon = entry.iconID and ("|T" .. entry.iconID .. ":16|t ") or ""
+        local name = entry.name or C_Spell.GetSpellName(spellID) or ("Spell " .. spellID)
 
-    return args
-  end
-
-  local function RebuildTrackedBuffs(opts, db, addon)
-    if not opts then return end
-    local container = opts.args.trackedBuffs.args.list.args
-    if not container then return end
-
-    -- wipe gamle noder
-    for k in pairs(container) do container[k] = nil end
-
-    local _, class                         = UnitClass("player")
-    local specID                           = GetSpecializationInfo(GetSpecialization() or 0)
-
-    db.profile.trackedBuffs                = db.profile.trackedBuffs or {}
-    db.profile.trackedBuffs[class]         = db.profile.trackedBuffs[class] or {}
-    db.profile.trackedBuffs[class][specID] = db.profile.trackedBuffs[class][specID] or {}
-
-    local snapshot                         = db.profile.cdmSnapshot
-        and db.profile.cdmSnapshot[class]
-        and db.profile.cdmSnapshot[class][specID]
-
-    if not snapshot then return end
-
-    local order = 10
-    for buffID, data in pairs(snapshot) do
-      if data.category == "buff" then
-        local icon = data.iconID and ("|T" .. data.iconID .. ":16|t ") or ""
-        local name = data.name or ("Buff " .. buffID)
-
-        container["buff" .. buffID] = {
-          type  = "toggle",
-          name  = icon .. name .. " (" .. buffID .. ")",
-          desc  = data.desc or "No description",
+        entries[spellID] = {
+          buffID = spellID,
+          entry = entry,
+          icon = icon,
+          name = name,
+          hasBuff = hasBuff and true or false,
+          hasBar = hasBar and true or false,
           order = order,
-          get   = function()
-            return db.profile.trackedBuffs[class][specID][buffID] or false
-          end,
-          set   = function(_, val)
-            db.profile.trackedBuffs[class][specID][buffID] = val or nil
-            addon:BuildFramesForSpec()
-            RebuildTrackedBuffs(opts, db, addon)
-            LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-          end,
         }
-
-        order = order + 1
       end
     end
   end
 
-  local function RebuildBuffLinks(opts, db, addon)
-    if not opts then return end
-    local container = opts.args.buffLinks.args.list.args
-    if not container then return end
-
-    -- wipe gamle noder
-    for k in pairs(container) do container[k] = nil end
-
-    local _, class = UnitClass("player")
-    local specID   = GetSpecializationInfo(GetSpecialization() or 0)
-
-    local links    = (db.profile.buffLinks[class] and db.profile.buffLinks[class][specID]) or {}
-
-    -- bygg nye noder
-    local order    = 10
-    for buffID, spellID in pairs(links) do
-      local buffInfo             = C_Spell.GetSpellInfo(buffID)
-      local spellInfo            = C_Spell.GetSpellInfo(spellID)
-
-      local buffName             = buffInfo and buffInfo.name or "Unknown Buff"
-      local buffIcon             = buffInfo and buffInfo.iconID or 134400
-      local spellName            = spellInfo and spellInfo.name or "Unknown Spell"
-      local spellIcon            = spellInfo and spellInfo.iconID or 134400
-
-      container["map" .. buffID] = {
-        type = "group",
-        name = ("|T%d:16|t %s (%d) -> |T%d:16|t %s (%d)"):format(
-          buffIcon, buffName, buffID, spellIcon, spellName, spellID
-        ),
-        inline = true,
-        order = order,
-        args = {
-          newSpellID = {
-            type = "input",
-            name = "Endre SpellID",
-            width = "half",
-            get = function() return tostring(spellID) end,
-            set = function(_, val)
-              local newID = tonumber(val)
-              if newID then
-                db.profile.buffLinks[class][specID][buffID] = newID
-                addon:BuildFramesForSpec()
-                RebuildBuffLinks(opts, db, addon)
-                LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-              end
-            end,
-          },
-          remove = {
-            type = "execute",
-            name = "Remove",
-            confirm = true,
-            func = function()
-              db.profile.buffLinks[class][specID][buffID] = nil
-              addon:BuildFramesForSpec()
-              RebuildBuffLinks(opts, db, addon)
-              LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-            end,
-          },
-        },
+  for buffID in pairs(tracked) do
+    if not entries[buffID] then
+      local info = C_Spell.GetSpellInfo(buffID)
+      entries[buffID] = {
+        buffID = buffID,
+        entry = nil,
+        icon = info and info.iconID and ("|T" .. info.iconID .. ":16|t ") or "",
+        name = info and info.name or ("Spell " .. buffID),
+        hasBuff = true,
+        hasBar = false,
+        order = math.huge,
       }
-      order                      = order + 1
     end
   end
 
-
-
-  function ClassHUD:GetUtilityOptions()
-    return {
-      type = "group",
-      name = "Utility Cooldowns",
-      args = BuildUtilityOptions(),
-    }
+  local list = {}
+  for _, data in pairs(entries) do
+    table.insert(list, data)
   end
 
-  --------------------------------------------------------------------
-  -- Options table
-  --------------------------------------------------------------------
+  table.sort(list, function(a, b)
+    if a.order == b.order then
+      return a.name < b.name
+    end
+    return a.order < b.order
+  end)
+
+  if #list == 0 then
+    container.empty = {
+      type = "description",
+      name = "No tracked buffs or bars available for this specialization.",
+      order = 1,
+    }
+    return
+  end
+
+  local order = 1
+  for _, data in ipairs(list) do
+    local buffID = data.buffID
+    local header = string.format("%s%s (%d)", data.icon or "", data.name or ("Spell " .. buffID), buffID)
+
+    local function getConfig(create)
+      return addon:GetTrackedEntryConfig(class, specID, buffID, create)
+    end
+
+    container["buff" .. buffID] = {
+      type = "group",
+      name = header,
+      inline = true,
+      order = order,
+      args = {
+        showIcon = {
+          type = "toggle",
+          name = "Show as Icon",
+          order = 1,
+          get = function()
+            local cfg = getConfig(false)
+            return cfg and cfg.showIcon or false
+          end,
+          set = function(_, value)
+            local cfg = getConfig(true)
+            cfg.showIcon = not not value
+            addon:BuildTrackedBuffFrames()
+            BuildTrackedBuffArgs(addon, container)
+            NotifyOptionsChanged()
+          end,
+        },
+        showBar = {
+          type = "toggle",
+          name = "Show as Bar",
+          order = 2,
+          disabled = not data.hasBar,
+          get = function()
+            local cfg = getConfig(false)
+            return cfg and cfg.showBar or false
+          end,
+          set = function(_, value)
+            local cfg = getConfig(true)
+            cfg.showBar = not not value
+            addon:BuildTrackedBuffFrames()
+            BuildTrackedBuffArgs(addon, container)
+            NotifyOptionsChanged()
+          end,
+        },
+        barShowIcon = {
+          type = "toggle",
+          name = "Show Icon",
+          order = 3,
+          hidden = function()
+            local cfg = getConfig(false)
+            return not (data.hasBar and cfg and cfg.showBar)
+          end,
+          get = function()
+            local cfg = getConfig(false)
+            return not cfg or cfg.barShowIcon ~= false
+          end,
+          set = function(_, value)
+            local cfg = getConfig(true)
+            cfg.barShowIcon = not not value
+            addon:BuildTrackedBuffFrames()
+            NotifyOptionsChanged()
+          end,
+        },
+        barColor = {
+          type = "color",
+          name = "Bar Color",
+          order = 4,
+          hasAlpha = true,
+          hidden = function()
+            local cfg = getConfig(false)
+            return not (data.hasBar and cfg and cfg.showBar)
+          end,
+          get = function()
+            local cfg = getConfig(false)
+            local color = (cfg and cfg.barColor) or addon:GetDefaultTrackedBarColor()
+            return color.r, color.g, color.b, color.a or 1
+          end,
+          set = function(_, r, g, b, a)
+            local cfg = getConfig(true)
+            cfg.barColor = { r = r, g = g, b = b, a = a or 1 }
+            addon:BuildTrackedBuffFrames()
+            NotifyOptionsChanged()
+          end,
+        },
+        barTimer = {
+          type = "toggle",
+          name = "Show Timer",
+          order = 5,
+          hidden = function()
+            local cfg = getConfig(false)
+            return not (data.hasBar and cfg and cfg.showBar)
+          end,
+          get = function()
+            local cfg = getConfig(false)
+            return not cfg or cfg.barShowTimer ~= false
+          end,
+          set = function(_, value)
+            local cfg = getConfig(true)
+            cfg.barShowTimer = not not value
+            addon:BuildTrackedBuffFrames()
+            NotifyOptionsChanged()
+          end,
+        },
+      },
+    }
+
+    order = order + 1
+  end
+end
+
+local function BuildBuffLinkArgs(addon, container)
+  for k in pairs(container) do container[k] = nil end
+
+  local class, specID = addon:GetPlayerClassSpec()
+  addon.db.profile.buffLinks[class] = addon.db.profile.buffLinks[class] or {}
+  addon.db.profile.buffLinks[class][specID] = addon.db.profile.buffLinks[class][specID] or {}
+
+  local links = addon.db.profile.buffLinks[class][specID]
+  local order = 1
+
+  if not next(links) then
+    container.empty = {
+      type = "description",
+      name = "No manual links stored for this spec. They are created automatically when buffs reference spells in their description.",
+      order = order,
+    }
+    return
+  end
+
+  local sorted = {}
+  for buffID, spellID in pairs(links) do
+    table.insert(sorted, { buffID = buffID, spellID = spellID })
+  end
+  table.sort(sorted, function(a, b) return a.buffID < b.buffID end)
+
+  for _, map in ipairs(sorted) do
+    local buffInfo = C_Spell.GetSpellInfo(map.buffID)
+    local spellInfo = C_Spell.GetSpellInfo(map.spellID)
+    local name = string.format("|T%d:16|t %s (%d) → |T%d:16|t %s (%d)",
+      buffInfo and buffInfo.iconID or 134400,
+      buffInfo and buffInfo.name or "Buff",
+      map.buffID,
+      spellInfo and spellInfo.iconID or 134400,
+      spellInfo and spellInfo.name or "Spell",
+      map.spellID)
+
+    container["link" .. map.buffID] = {
+      type = "group",
+      name = name,
+      inline = true,
+      order = order,
+      args = {
+        buff = {
+          type = "input",
+          name = "Buff ID",
+          width = "half",
+          order = 1,
+          get = function() return tostring(map.buffID) end,
+          set = function(_, value)
+            local newID = tonumber(value)
+            if newID and newID ~= map.buffID then
+              local current = addon.db.profile.buffLinks[class][specID][map.buffID]
+              addon.db.profile.buffLinks[class][specID][map.buffID] = nil
+              addon.db.profile.buffLinks[class][specID][newID] = current
+              addon:BuildFramesForSpec()
+              BuildBuffLinkArgs(addon, container)
+              NotifyOptionsChanged()
+            end
+          end,
+        },
+        spell = {
+          type = "input",
+          name = "Spell ID",
+          width = "half",
+          order = 2,
+          get = function() return tostring(map.spellID) end,
+          set = function(_, value)
+            local newID = tonumber(value)
+            if newID then
+              addon.db.profile.buffLinks[class][specID][map.buffID] = newID
+              addon:BuildFramesForSpec()
+              BuildBuffLinkArgs(addon, container)
+              NotifyOptionsChanged()
+            end
+          end,
+        },
+        remove = {
+          type = "execute",
+          name = "Remove",
+          confirm = true,
+          order = 3,
+          func = function()
+            addon.db.profile.buffLinks[class][specID][map.buffID] = nil
+            addon:BuildFramesForSpec()
+            BuildBuffLinkArgs(addon, container)
+            NotifyOptionsChanged()
+          end,
+        },
+      },
+    }
+
+    order = order + 1
+  end
+end
+
+function ClassHUD_BuildOptions(addon)
+  local db = addon.db
+
+  db.profile.textures = db.profile.textures or { bar = "Blizzard", font = "Friz Quadrata TT" }
+  db.profile.show = db.profile.show or { cast = true, hp = true, resource = true, power = true, buffs = true }
+  db.profile.height = db.profile.height or { cast = 18, hp = 14, resource = 14, power = 14 }
+  db.profile.colors = db.profile.colors or {
+    hp = { r = 0.10, g = 0.80, b = 0.10 },
+    resourceClass = true,
+    resource = { r = 0.00, g = 0.55, b = 1.00 },
+    power = { r = 1.00, g = 0.85, b = 0.10 },
+  }
+  db.profile.position = db.profile.position or { x = 0, y = -50 }
+  db.profile.position.x = db.profile.position.x or 0
+  db.profile.position.y = db.profile.position.y or -50
+  db.profile.topBar = db.profile.topBar or {}
+  db.profile.topBar.perRow = db.profile.topBar.perRow or 8
+  db.profile.topBar.spacingX = db.profile.topBar.spacingX or 4
+  db.profile.topBar.spacingY = db.profile.topBar.spacingY or 4
+  db.profile.topBar.yOffset = db.profile.topBar.yOffset or 0
+  db.profile.topBar.grow = db.profile.topBar.grow or "UP"
+  db.profile.bottomBar = db.profile.bottomBar or {}
+  db.profile.bottomBar.perRow = db.profile.bottomBar.perRow or 8
+  db.profile.bottomBar.spacingX = db.profile.bottomBar.spacingX or 4
+  db.profile.bottomBar.spacingY = db.profile.bottomBar.spacingY or 4
+  db.profile.bottomBar.yOffset = db.profile.bottomBar.yOffset or 0
+  db.profile.sideBars = db.profile.sideBars or {}
+  db.profile.sideBars.size = db.profile.sideBars.size or 36
+  db.profile.sideBars.spacing = db.profile.sideBars.spacing or 4
+  db.profile.sideBars.offset = db.profile.sideBars.offset or 6
+  db.profile.trackedBuffBar = db.profile.trackedBuffBar or {}
+  db.profile.trackedBuffBar.perRow = db.profile.trackedBuffBar.perRow or 8
+  db.profile.trackedBuffBar.spacingX = db.profile.trackedBuffBar.spacingX or 4
+  db.profile.trackedBuffBar.spacingY = db.profile.trackedBuffBar.spacingY or 4
+  db.profile.trackedBuffBar.yOffset = db.profile.trackedBuffBar.yOffset or 4
+  db.profile.trackedBuffBar.align = db.profile.trackedBuffBar.align or "CENTER"
+  db.profile.trackedBuffBar.height = db.profile.trackedBuffBar.height or 16
+  db.profile.utilityPlacement = db.profile.utilityPlacement or {}
+  db.profile.trackedBuffs = db.profile.trackedBuffs or {}
+  db.profile.buffLinks = db.profile.buffLinks or {}
+
+  local topBarContainer = {}
+  local utilityContainer = {}
+  local trackedContainer = {}
+  local linkContainer = {}
+
   local opts = {
     type = "group",
     name = "ClassHUD",
     childGroups = "tab",
     args = {
-      ----------------------------------------------------------------
-      -- Bars (global config) — FULL like your original
-      ----------------------------------------------------------------
-      bars = {
+      general = {
         type = "group",
-        name = "Bars",
+        name = "General",
         order = 1,
         args = {
           locked = {
             type = "toggle",
-            name = "Lock frame",
+            name = "Lock Frame",
             order = 1,
-            set = function(_, v) db.profile.locked = v end,
             get = function() return db.profile.locked end,
+            set = function(_, value)
+              db.profile.locked = value
+            end,
           },
           width = {
             type = "range",
-            name = "Width",
-            min = 240,
-            max = 800,
+            name = "Bar Width",
+            min = 200,
+            max = 600,
             step = 1,
             order = 2,
-            set = function(_, v)
-              db.profile.width = v
-              addon:FullUpdate()
-              if addon.BuildFramesForSpec then addon:BuildFramesForSpec() end
-            end,
             get = function() return db.profile.width end,
+            set = function(_, value)
+              db.profile.width = value
+              addon:FullUpdate()
+              addon:BuildFramesForSpec()
+            end,
+          },
+          positionX = {
+            type = "range",
+            name = "Position X",
+            order = 3,
+            min = -1000,
+            max = 1000,
+            step = 1,
+            get = function() return db.profile.position.x or 0 end,
+            set = function(_, value)
+              db.profile.position.x = value
+              addon:ApplyAnchorPosition()
+            end,
+          },
+          positionY = {
+            type = "range",
+            name = "Position Y",
+            order = 4,
+            min = -1000,
+            max = 1000,
+            step = 1,
+            get = function() return db.profile.position.y or 0 end,
+            set = function(_, value)
+              db.profile.position.y = value
+              addon:ApplyAnchorPosition()
+            end,
           },
           spacing = {
             type = "range",
-            name = "Bar spacing",
+            name = "Bar Spacing",
             min = 0,
             max = 12,
             step = 1,
-            order = 3,
-            set = function(_, v)
-              db.profile.spacing = v
+            order = 5,
+            get = function() return db.profile.spacing or 2 end,
+            set = function(_, value)
+              db.profile.spacing = value
               addon:FullUpdate()
-              if addon.BuildFramesForSpec then addon:BuildFramesForSpec() end
+              addon:BuildFramesForSpec()
             end,
-            get = function() return db.profile.spacing end,
           },
-          tex = {
+          texture = {
             type = "select",
+            name = "Bar Texture",
             dialogControl = "LSM30_Statusbar",
-            order = 4,
-            name = "Bar texture",
-            values = (LSM and LSM:HashTable("statusbar")) or {},
-            set = function(_, k)
-              db.profile.textures.bar = k; addon:FullUpdate()
-            end,
+            order = 6,
+            values = LSM and LSM:HashTable("statusbar") or {},
             get = function() return db.profile.textures.bar end,
+            set = function(_, value)
+              db.profile.textures.bar = value
+              addon:ApplyBarSkins()
+            end,
           },
           font = {
             type = "select",
-            dialogControl = "LSM30_Font",
-            order = 5,
             name = "Font",
-            values = (LSM and LSM:HashTable("font")) or {},
-            set = function(_, k)
-              db.profile.textures.font = k; addon:FullUpdate()
-            end,
-            get = function() return db.profile.textures.font end,
-          },
-
-          -- Position
-          posX = {
-            type = "range",
-            name = "Position X",
-            min = -500,
-            max = 500,
-            step = 1,
-            order = 6,
-            set = function(_, v)
-              db.profile.position.x = v; addon:ApplyAnchorPosition()
-            end,
-            get = function() return db.profile.position.x or 0 end,
-          },
-          posY = {
-            type = "range",
-            name = "Position Y",
-            min = -500,
-            max = 500,
-            step = 1,
+            dialogControl = "LSM30_Font",
             order = 7,
-            set = function(_, v)
-              db.profile.position.y = v; addon:ApplyAnchorPosition()
+            values = LSM and LSM:HashTable("font") or {},
+            get = function() return db.profile.textures.font end,
+            set = function(_, value)
+              db.profile.textures.font = value
+              addon:FullUpdate()
+              addon:BuildFramesForSpec()
             end,
-            get = function() return db.profile.position.y or 0 end,
           },
-
-          -- Cast
-          castShow = {
+        },
+      },
+      bars = {
+        type = "group",
+        name = "Bars",
+        order = 2,
+        inline = false,
+        args = {
+          showCast = {
             type = "toggle",
             name = "Show Cast Bar",
-            order = 10,
-            set = function(_, v)
-              db.profile.show.cast = v; addon:FullUpdate()
-            end,
+            order = 1,
             get = function() return db.profile.show.cast end,
+            set = function(_, value)
+              db.profile.show.cast = value
+              addon:FullUpdate()
+            end,
           },
-          castH = {
+          showHP = {
+            type = "toggle",
+            name = "Show Health Bar",
+            order = 2,
+            get = function() return db.profile.show.hp end,
+            set = function(_, value)
+              db.profile.show.hp = value
+              addon:FullUpdate()
+            end,
+          },
+          showResource = {
+            type = "toggle",
+            name = "Show Primary Resource",
+            order = 3,
+            get = function() return db.profile.show.resource end,
+            set = function(_, value)
+              db.profile.show.resource = value
+              addon:FullUpdate()
+            end,
+          },
+          showPower = {
+            type = "toggle",
+            name = "Show Special Power",
+            order = 4,
+            get = function() return db.profile.show.power end,
+            set = function(_, value)
+              db.profile.show.power = value
+              addon:FullUpdate()
+            end,
+          },
+          showBuffs = {
+            type = "toggle",
+            name = "Show Tracked Buff Bar",
+            order = 5,
+            get = function() return db.profile.show.buffs end,
+            set = function(_, value)
+              db.profile.show.buffs = value
+              addon:BuildTrackedBuffFrames()
+            end,
+          },
+          trackedBarHeight = {
+            type = "range",
+            name = "Tracked Bar Height",
+            order = 6,
+            min = 8,
+            max = 40,
+            step = 1,
+            get = function() return db.profile.trackedBuffBar.height or 16 end,
+            set = function(_, value)
+              db.profile.trackedBuffBar.height = value
+              addon:BuildTrackedBuffFrames()
+            end,
+          },
+          powerSpacing = {
+            type = "range",
+            name = "Segment Spacing",
+            order = 7,
+            min = 0,
+            max = 12,
+            step = 1,
+            get = function() return db.profile.powerSpacing or 2 end,
+            set = function(_, value)
+              db.profile.powerSpacing = value
+              addon:FullUpdate()
+            end,
+          },
+          heightCast = {
             type = "range",
             name = "Cast Height",
-            min = 10,
-            max = 30,
+            order = 8,
+            min = 8,
+            max = 40,
             step = 1,
-            order = 11,
-            set = function(_, v)
-              db.profile.height.cast = v; addon:FullUpdate()
-            end,
             get = function() return db.profile.height.cast end,
-          },
-
-          -- HP
-          hpShow = {
-            type = "toggle",
-            name = "Show HP Bar",
-            order = 20,
-            set = function(_, v)
-              db.profile.show.hp = v; addon:FullUpdate()
+            set = function(_, value)
+              db.profile.height.cast = value
+              addon:FullUpdate()
             end,
-            get = function() return db.profile.show.hp end,
           },
-          hpH = {
+          heightHP = {
             type = "range",
-            name = "HP Height",
+            name = "Health Height",
+            order = 9,
             min = 8,
-            max = 30,
+            max = 40,
             step = 1,
-            order = 21,
-            set = function(_, v)
-              db.profile.height.hp = v; addon:FullUpdate()
-            end,
             get = function() return db.profile.height.hp end,
-          },
-
-          -- Primary Resource
-          resShow = {
-            type = "toggle",
-            name = "Show Primary Resource Bar",
-            order = 30,
-            set = function(_, v)
-              db.profile.show.resource = v; addon:FullUpdate()
+            set = function(_, value)
+              db.profile.height.hp = value
+              addon:FullUpdate()
             end,
-            get = function() return db.profile.show.resource end,
           },
-          resH = {
+          heightResource = {
             type = "range",
-            name = "Primary Height",
+            name = "Resource Height",
+            order = 10,
             min = 8,
-            max = 30,
+            max = 40,
             step = 1,
-            order = 31,
-            set = function(_, v)
-              db.profile.height.resource = v; addon:FullUpdate()
-            end,
             get = function() return db.profile.height.resource end,
-          },
-          resClass = {
-            type = "toggle",
-            name = "Primary uses Class Color",
-            order = 32,
-            set = function(_, v)
-              db.profile.colors.resourceClass = v; addon:FullUpdate()
-            end,
-            get = function() return db.profile.colors.resourceClass end,
-          },
-          resColor = {
-            type = "color",
-            name = "Primary Custom Color",
-            hasAlpha = false,
-            order = 33,
-            set = function(_, r, g, b)
-              db.profile.colors.resource = { r = r, g = g, b = b }; addon:FullUpdate()
-            end,
-            get = function()
-              local c = db.profile.colors.resource; return c.r, c.g, c.b
+            set = function(_, value)
+              db.profile.height.resource = value
+              addon:FullUpdate()
             end,
           },
-
-          -- Special Power
-          powShow = {
-            type = "toggle",
-            name = "Show Special Power Bar",
-            order = 40,
-            set = function(_, v)
-              db.profile.show.power = v; addon:FullUpdate()
-            end,
-            get = function() return db.profile.show.power end,
-          },
-          powH = {
+          heightPower = {
             type = "range",
-            name = "Special Height",
+            name = "Special Power Height",
+            order = 11,
             min = 8,
-            max = 30,
+            max = 40,
             step = 1,
-            order = 41,
-            set = function(_, v)
-              db.profile.height.power = v; addon:FullUpdate()
-            end,
             get = function() return db.profile.height.power end,
-          },
-          powS = {
-            type = "range",
-            name = "Special spacing",
-            min = 0,
-            max = 10,
-            step = 1,
-            order = 42,
-            set = function(_, v)
-              db.profile.powerSpacing = v; addon:FullUpdate()
-            end,
-            get = function() return db.profile.powerSpacing end,
-          },
-          powColor = {
-            type = "color",
-            name = "Special Segment Color",
-            hasAlpha = false,
-            order = 43,
-            set = function(_, r, g, b)
-              db.profile.colors.power = { r = r, g = g, b = b }; addon:FullUpdate()
-            end,
-            get = function()
-              local c = db.profile.colors.power; return c.r, c.g, c.b
+            set = function(_, value)
+              db.profile.height.power = value
+              addon:FullUpdate()
             end,
           },
-          iconText = {
+          topLayout = {
             type = "group",
-            name = "Icon Text",
+            name = "Top Bar Layout",
+            order = 20,
             inline = true,
-            order = 50,
             args = {
-              headerCount = { type = "header", name = "Charge Count", order = 1 },
-              countSize = {
+              perRow = {
                 type = "range",
-                name = "Size",
-                min = 8,
-                max = 32,
+                name = "Spells per Row",
+                order = 1,
+                min = 1,
+                max = 12,
                 step = 1,
+                get = function() return db.profile.topBar.perRow end,
+                set = function(_, value)
+                  db.profile.topBar.perRow = value
+                  addon:BuildFramesForSpec()
+                end,
+              },
+              spacingX = {
+                type = "range",
+                name = "Horizontal Spacing",
                 order = 2,
-                set = function(_, v)
-                  db.profile.iconText.count.size = v; addon:BuildFramesForSpec()
+                min = 0,
+                max = 20,
+                step = 1,
+                get = function() return db.profile.topBar.spacingX end,
+                set = function(_, value)
+                  db.profile.topBar.spacingX = value
+                  addon:BuildFramesForSpec()
                 end,
-                get = function() return db.profile.iconText.count.size end,
               },
-              countColor = {
-                type = "color",
-                name = "Color",
-                hasAlpha = false,
+              spacingY = {
+                type = "range",
+                name = "Vertical Spacing",
                 order = 3,
-                set = function(_, r, g, b)
-                  db.profile.iconText.count.color = { r = r, g = g, b = b }; addon:BuildFramesForSpec()
-                end,
-                get = function()
-                  local c = db.profile.iconText.count.color; return c.r, c.g, c.b
+                min = 0,
+                max = 20,
+                step = 1,
+                get = function() return db.profile.topBar.spacingY end,
+                set = function(_, value)
+                  db.profile.topBar.spacingY = value
+                  addon:BuildFramesForSpec()
                 end,
               },
-              countPoint = {
-                type = "select",
-                name = "Position",
+              yOffset = {
+                type = "range",
+                name = "Vertical Offset",
                 order = 4,
-                values = { TOPLEFT = "Top Left", TOPRIGHT = "Top Right", BOTTOMLEFT = "Bottom Left", BOTTOMRIGHT = "Bottom Right", CENTER = "Center" },
-                set = function(_, v)
-                  db.profile.iconText.count.point = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.iconText.count.point end,
-              },
-              countOfsX = {
-                type = "range",
-                name = "Offset X",
-                min = -20,
-                max = 20,
+                min = -100,
+                max = 100,
                 step = 1,
-                order = 5,
-                set = function(_, v)
-                  db.profile.iconText.count.ofsX = v; addon:BuildFramesForSpec()
+                get = function() return db.profile.topBar.yOffset end,
+                set = function(_, value)
+                  db.profile.topBar.yOffset = value
+                  addon:BuildFramesForSpec()
                 end,
-                get = function() return db.profile.iconText.count.ofsX end,
-              },
-              countOfsY = {
-                type = "range",
-                name = "Offset Y",
-                min = -20,
-                max = 20,
-                step = 1,
-                order = 6,
-                set = function(_, v)
-                  db.profile.iconText.count.ofsY = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.iconText.count.ofsY end,
-              },
-
-              spacer1 = { type = "description", name = " ", order = 9 },
-
-              headerAura = { type = "header", name = "Aura ID Label", order = 10 },
-              auraEnabled = {
-                type = "toggle",
-                name = "Show Aura ID",
-                order = 11,
-                set = function(_, v)
-                  db.profile.iconText.aura.enabled = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.iconText.aura.enabled end,
-              },
-              auraSize = {
-                type = "range",
-                name = "Size",
-                min = 8,
-                max = 32,
-                step = 1,
-                order = 12,
-                set = function(_, v)
-                  db.profile.iconText.aura.size = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.iconText.aura.size end,
-              },
-              auraColor = {
-                type = "color",
-                name = "Color",
-                hasAlpha = false,
-                order = 13,
-                set = function(_, r, g, b)
-                  db.profile.iconText.aura.color = { r = r, g = g, b = b }; addon:BuildFramesForSpec()
-                end,
-                get = function()
-                  local c = db.profile.iconText.aura.color; return c.r, c.g, c.b
-                end,
-              },
-              auraPoint = {
-                type = "select",
-                name = "Position",
-                order = 14,
-                values = { TOPLEFT = "Top Left", TOPRIGHT = "Top Right", BOTTOMLEFT = "Bottom Left", BOTTOMRIGHT = "Bottom Right", CENTER = "Center" },
-                set = function(_, v)
-                  db.profile.iconText.aura.point = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.iconText.aura.point end,
-              },
-              auraOfsX = {
-                type = "range",
-                name = "Offset X",
-                min = -20,
-                max = 20,
-                step = 1,
-                order = 15,
-                set = function(_, v)
-                  db.profile.iconText.aura.ofsX = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.iconText.aura.ofsX end,
-              },
-              auraOfsY = {
-                type = "range",
-                name = "Offset Y",
-                min = -20,
-                max = 20,
-                step = 1,
-                order = 16,
-                set = function(_, v)
-                  db.profile.iconText.aura.ofsY = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.iconText.aura.ofsY end,
               },
             },
           },
-
-        },
-      },
-      ----------------------------------------------------------------
-      -- Top Bar (tabs: Layout + Tracked Spells)
-      ----------------------------------------------------------------
-      topBar = {
-        type = "group",
-        name = "Top Bar",
-        order = 3,
-        childGroups = "tab",
-        args = {
-          layout = {
+          bottomLayout = {
             type = "group",
-            name = "Layout",
-            order = 1,
+            name = "Bottom Bar Layout",
+            order = 21,
+            inline = true,
             args = {
               perRow = {
                 type = "range",
-                name = "Icons per Row",
+                name = "Spells per Row",
+                order = 1,
                 min = 1,
-                max = 20,
+                max = 12,
                 step = 1,
-                set = function(_, v)
-                  db.profile.topBar.perRow = v; addon:BuildFramesForSpec()
+                get = function() return db.profile.bottomBar.perRow end,
+                set = function(_, value)
+                  db.profile.bottomBar.perRow = value
+                  addon:BuildFramesForSpec()
                 end,
-                get = function() return db.profile.topBar.perRow or 8 end,
               },
               spacingX = {
                 type = "range",
                 name = "Horizontal Spacing",
+                order = 2,
                 min = 0,
                 max = 20,
                 step = 1,
-                set = function(_, v)
-                  db.profile.topBar.spacingX = v; addon:BuildFramesForSpec()
+                get = function() return db.profile.bottomBar.spacingX end,
+                set = function(_, value)
+                  db.profile.bottomBar.spacingX = value
+                  addon:BuildFramesForSpec()
                 end,
-                get = function() return db.profile.topBar.spacingX or 4 end,
               },
               spacingY = {
                 type = "range",
                 name = "Vertical Spacing",
+                order = 3,
                 min = 0,
                 max = 20,
                 step = 1,
-                set = function(_, v)
-                  db.profile.topBar.spacingY = v; addon:BuildFramesForSpec()
+                get = function() return db.profile.bottomBar.spacingY end,
+                set = function(_, value)
+                  db.profile.bottomBar.spacingY = value
+                  addon:BuildFramesForSpec()
                 end,
-                get = function() return db.profile.topBar.spacingY or 4 end,
               },
               yOffset = {
                 type = "range",
-                name = "Y Offset",
-                min = -200,
-                max = 200,
+                name = "Vertical Offset",
+                order = 4,
+                min = -100,
+                max = 100,
                 step = 1,
-                set = function(_, v)
-                  db.profile.topBar.yOffset = v; addon:BuildFramesForSpec()
+                get = function() return db.profile.bottomBar.yOffset end,
+                set = function(_, value)
+                  db.profile.bottomBar.yOffset = value
+                  addon:BuildFramesForSpec()
                 end,
-                get = function() return db.profile.topBar.yOffset or 0 end,
-              },
-              grow = {
-                type = "select",
-                name = "Vekst-retning",
-                desc = "Om Top Bar utvider seg oppover eller nedover når det er flere rader.",
-                values = { UP = "Opp", DOWN = "Ned" },
-                get = function() return db.profile.topBar.grow or "DOWN" end,
-                set = function(_, val)
-                  db.profile.topBar.grow = val; addon:BuildFramesForSpec()
-                end,
-                order = 50,
-              },
-              align = {
-                type = "select",
-                name = "Buff Anchor X-pos",
-                desc = "Plassering av Tracked Buffs-bar i forhold til Top Bar.",
-                values = { LEFT = "Venstre", CENTER = "Midt", RIGHT = "Høyre" },
-                get = function() return db.profile.topBar.align or "CENTER" end,
-                set = function(_, val)
-                  db.profile.topBar.align = val; addon:BuildFramesForSpec()
-                end,
-                order = 51,
-              },
-
-            },
-          },
-
-          -- Tracked Spells
-          addSpell = {
-            type = "input",
-            name = "Add Spell ID",
-            order = 2,
-            set = function(_, val)
-              local id = tonumber(val)
-              local info = id and C_Spell.GetSpellInfo(id)
-              if not info then
-                print("|cffff0000Invalid spell ID:|r", val)
-                return
-              end
-              local specID = GetSpecializationInfo(GetSpecialization() or 0)
-              db.profile.topBarSpells[specID] = db.profile.topBarSpells[specID] or {}
-              table.insert(db.profile.topBarSpells[specID],
-                { spellID = id, trackCooldown = true, glowEnabled = true, iconFromAura = true }
-              )
-              addon:BuildFramesForSpec()
-              RebuildSpellTree(opts, db, addon, "top")
-              ForceRefresh("top")
-            end,
-            get = function() return "" end,
-          },
-          addFromList = {
-            type = "select",
-            name = "Add From List",
-            order = 3,
-            values = function()
-              local _, class    = UnitClass("player")
-              local specID      = GetSpecializationInfo(GetSpecialization() or 0)
-              local out         = {}
-              local classTable  = suggestedSpells[class] or {}
-              local specList    = classTable[specID] or {}
-              local utilityList = classTable.UTILITY or {}
-              for _, spell in ipairs(specList) do
-                local info = C_Spell.GetSpellInfo(spell.id)
-                if info then out[spell.id] = ("|T%d:16|t %s (%d)"):format(info.iconID, info.name, spell.id) end
-              end
-              for _, spell in ipairs(utilityList) do
-                local info = C_Spell.GetSpellInfo(spell.id)
-                if info then out[spell.id] = ("|T%d:16|t %s (%d) [Utility]"):format(info.iconID, info.name, spell.id) end
-              end
-              return out
-            end,
-            set = function(_, val)
-              local specID = GetSpecializationInfo(GetSpecialization() or 0)
-              db.profile.topBarSpells[specID] = db.profile.topBarSpells[specID] or {}
-              table.insert(db.profile.topBarSpells[specID], { spellID = val, trackCooldown = true })
-              addon:BuildFramesForSpec()
-              RebuildSpellTree(opts, db, addon, "top")
-              ForceRefresh("top")
-            end,
-            get = function() return nil end,
-          },
-          spells = { type = "group", name = "Tracked Spells", order = 4, args = {} },
-        },
-      },
-
-      ----------------------------------------------------------------
-      -- Bottom Bar (tabs: Layout + Tracked Spells)
-      ----------------------------------------------------------------
-      bottomBar = {
-        type = "group",
-        name = "Bottom Bar",
-        order = 4,
-        childGroups = "tab",
-        args = {
-          layout = {
-            type = "group",
-            name = "Layout",
-            order = 1,
-            args = {
-              perRow = {
-                type = "range",
-                name = "Icons per Row",
-                min = 1,
-                max = 20,
-                step = 1,
-                set = function(_, v)
-                  db.profile.bottomBar.perRow = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.bottomBar.perRow or 8 end,
-              },
-              spacingX = {
-                type = "range",
-                name = "Horizontal Spacing",
-                min = 0,
-                max = 20,
-                step = 1,
-                set = function(_, v)
-                  db.profile.bottomBar.spacingX = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.bottomBar.spacingX or 4 end,
-              },
-              spacingY = {
-                type = "range",
-                name = "Vertical Spacing",
-                min = 0,
-                max = 20,
-                step = 1,
-                set = function(_, v)
-                  db.profile.bottomBar.spacingY = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.bottomBar.spacingY or 4 end,
-              },
-              yOffset = {
-                type = "range",
-                name = "Y Offset",
-                min = -200,
-                max = 200,
-                step = 1,
-                set = function(_, v)
-                  db.profile.bottomBar.yOffset = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.bottomBar.yOffset or 0 end,
               },
             },
           },
-
-          -- Tracked Spells
-          addSpell = {
-            type = "input",
-            name = "Add Spell ID",
-            order = 2,
-            set = function(_, val)
-              local id = tonumber(val)
-              local info = id and C_Spell.GetSpellInfo(id)
-              if not info then
-                print("|cffff0000Invalid spell ID:|r", val)
-                return
-              end
-              local specID = GetSpecializationInfo(GetSpecialization() or 0)
-              db.profile.bottomBarSpells[specID] = db.profile.bottomBarSpells[specID] or {}
-              table.insert(db.profile.bottomBarSpells[specID],
-                { spellID = id, trackCooldown = true, glowEnabled = true, iconFromAura = true }
-              )
-              addon:BuildFramesForSpec()
-              RebuildSpellTree(opts, db, addon, "bottom")
-              ForceRefresh("bottom")
-            end,
-            get = function() return "" end,
-          },
-          addFromList = {
-            type = "select",
-            name = "Add From List",
-            order = 3,
-            values = function()
-              local _, class    = UnitClass("player")
-              local specID      = GetSpecializationInfo(GetSpecialization() or 0)
-              local out         = {}
-              local classTable  = suggestedSpells[class] or {}
-              local specList    = classTable[specID] or {}
-              local utilityList = classTable.UTILITY or {}
-              for _, spell in ipairs(specList) do
-                local info = C_Spell.GetSpellInfo(spell.id)
-                if info then out[spell.id] = ("|T%d:16|t %s (%d)"):format(info.iconID, info.name, spell.id) end
-              end
-              for _, spell in ipairs(utilityList) do
-                local info = C_Spell.GetSpellInfo(spell.id)
-                if info then out[spell.id] = ("|T%d:16|t %s (%d) [Utility]"):format(info.iconID, info.name, spell.id) end
-              end
-              return out
-            end,
-            set = function(_, val)
-              local specID = GetSpecializationInfo(GetSpecialization() or 0)
-              db.profile.bottomBarSpells[specID] = db.profile.bottomBarSpells[specID] or {}
-              table.insert(db.profile.bottomBarSpells[specID], { spellID = val, trackCooldown = true })
-              addon:BuildFramesForSpec()
-              RebuildSpellTree(opts, db, addon, "bottom")
-              ForceRefresh("bottom")
-            end,
-            get = function() return nil end,
-          },
-          spells = { type = "group", name = "Tracked Spells", order = 4, args = {} },
-        },
-      },
-      ----------------------------------------------------------------
-      -- Side Bars
-      ----------------------------------------------------------------
-      sidebars = {
-        type = "group",
-        name = "Sidebars",
-        order = 5,
-        childGroups = "tab",
-        args = {
-          -- Felles layout for venstre/høyre
-          layout = {
+          sideLayout = {
             type = "group",
-            name = "Layout",
-            order = 1,
+            name = "Side Bars",
+            order = 22,
+            inline = true,
             args = {
-              iconSize = {
+              size = {
                 type = "range",
                 name = "Icon Size",
-                min = 16,
-                max = 64,
+                order = 1,
+                min = 24,
+                max = 80,
                 step = 1,
-                set = function(_, v)
-                  db.profile.sideBars.size = v; addon:BuildFramesForSpec()
+                get = function() return db.profile.sideBars.size end,
+                set = function(_, value)
+                  db.profile.sideBars.size = value
+                  addon:BuildFramesForSpec()
                 end,
-                get = function() return db.profile.sideBars.size or 36 end,
               },
               spacing = {
                 type = "range",
-                name = "Icon Spacing",
+                name = "Spacing",
+                order = 2,
                 min = 0,
                 max = 20,
                 step = 1,
-                set = function(_, v)
-                  db.profile.sideBars.spacing = v; addon:BuildFramesForSpec()
+                get = function() return db.profile.sideBars.spacing end,
+                set = function(_, value)
+                  db.profile.sideBars.spacing = value
+                  addon:BuildFramesForSpec()
                 end,
-                get = function() return db.profile.sideBars.spacing or 4 end,
               },
               offset = {
                 type = "range",
-                name = "Spacing from HUD",
-                min = 0,
-                max = 100,
+                name = "Offset",
+                order = 3,
+                min = -200,
+                max = 200,
                 step = 1,
-                set = function(_, v)
-                  db.profile.sideBars.offset = v; addon:BuildFramesForSpec()
-                end,
-                get = function() return db.profile.sideBars.offset or 6 end,
-              },
-            },
-          },
-
-          -- Venstre sidebar (spells)
-          leftBar = {
-            type = "group",
-            name = "Left Bar",
-            order = 2,
-            args = {
-              addSpell = {
-                type = "input",
-                name = "Add Spell ID",
-                order = 1,
-                set = function(_, val)
-                  local id = tonumber(val)
-                  local info = id and C_Spell.GetSpellInfo(id)
-                  if not info then
-                    print("|cffff0000Invalid spell ID:|r", val); return
-                  end
-                  local specID = GetSpecializationInfo(GetSpecialization() or 0)
-                  db.profile.leftBarSpells[specID] = db.profile.leftBarSpells[specID] or {}
-                  table.insert(db.profile.leftBarSpells[specID],
-                    { spellID = id, trackCooldown = true, glowEnabled = true, iconFromAura = true }
-                  )
+                get = function() return db.profile.sideBars.offset end,
+                set = function(_, value)
+                  db.profile.sideBars.offset = value
                   addon:BuildFramesForSpec()
-                  RebuildSpellTree(opts, db, addon, "left")
-                  ForceRefresh("left")
                 end,
-                get = function() return "" end,
               },
-              addFromList = {
-                type = "select",
-                name = "Add From List",
-                order = 2,
-                values = function()
-                  local _, class    = UnitClass("player")
-                  local specID      = GetSpecializationInfo(GetSpecialization() or 0)
-                  local out         = {}
-                  local classTable  = (_G.ClassHUD_SpellSuggestions or {})[class] or {}
-                  local specList    = classTable[specID] or {}
-                  local utilityList = classTable.UTILITY or {}
-                  for _, s in ipairs(specList) do
-                    local i = C_Spell.GetSpellInfo(s.id)
-                    if i then out[s.id] = ("|T%d:16|t %s (%d)"):format(i.iconID, i.name, s.id) end
-                  end
-                  for _, s in ipairs(utilityList) do
-                    local i = C_Spell.GetSpellInfo(s.id)
-                    if i then out[s.id] = ("|T%d:16|t %s (%d) [Utility]"):format(i.iconID, i.name, s.id) end
-                  end
-                  return out
-                end,
-                set = function(_, val)
-                  local specID = GetSpecializationInfo(GetSpecialization() or 0)
-                  db.profile.leftBarSpells[specID] = db.profile.leftBarSpells[specID] or {}
-                  table.insert(db.profile.leftBarSpells[specID], { spellID = val, trackCooldown = true })
-                  addon:BuildFramesForSpec()
-                  RebuildSpellTree(opts, db, addon, "left")
-                  ForceRefresh("left")
-                end,
-                get = function() return nil end,
-              },
-              spells = { type = "group", name = "Tracked Spells", order = 3, args = {} },
-            },
-          },
-
-          -- Høyre sidebar (spells)
-          rightBar = {
-            type = "group",
-            name = "Right Bar",
-            order = 3,
-            args = {
-              addSpell = {
-                type = "input",
-                name = "Add Spell ID",
-                order = 1,
-                set = function(_, val)
-                  local id = tonumber(val)
-                  local info = id and C_Spell.GetSpellInfo(id)
-                  if not info then
-                    print("|cffff0000Invalid spell ID:|r", val); return
-                  end
-                  local specID = GetSpecializationInfo(GetSpecialization() or 0)
-                  db.profile.rightBarSpells[specID] = db.profile.rightBarSpells[specID] or {}
-                  table.insert(db.profile.rightBarSpells[specID],
-                    { spellID = id, trackCooldown = true, glowEnabled = true, iconFromAura = true }
-                  )
-                  addon:BuildFramesForSpec()
-                  RebuildSpellTree(opts, db, addon, "right")
-                  ForceRefresh("right")
-                end,
-                get = function() return "" end,
-              },
-              addFromList = {
-                type = "select",
-                name = "Add From List",
-                order = 2,
-                values = function()
-                  local _, class    = UnitClass("player")
-                  local specID      = GetSpecializationInfo(GetSpecialization() or 0)
-                  local out         = {}
-                  local classTable  = (_G.ClassHUD_SpellSuggestions or {})[class] or {}
-                  local specList    = classTable[specID] or {}
-                  local utilityList = classTable.UTILITY or {}
-                  for _, s in ipairs(specList) do
-                    local i = C_Spell.GetSpellInfo(s.id)
-                    if i then out[s.id] = ("|T%d:16|t %s (%d)"):format(i.iconID, i.name, s.id) end
-                  end
-                  for _, s in ipairs(utilityList) do
-                    local i = C_Spell.GetSpellInfo(s.id)
-                    if i then out[s.id] = ("|T%d:16|t %s (%d) [Utility]"):format(i.iconID, i.name, s.id) end
-                  end
-                  return out
-                end,
-                set = function(_, val)
-                  local specID = GetSpecializationInfo(GetSpecialization() or 0)
-                  db.profile.rightBarSpells[specID] = db.profile.rightBarSpells[specID] or {}
-                  table.insert(db.profile.rightBarSpells[specID], { spellID = val, trackCooldown = true })
-                  addon:BuildFramesForSpec()
-                  RebuildSpellTree(opts, db, addon, "right")
-                  ForceRefresh("right")
-                end,
-                get = function() return nil end,
-              },
-              spells = { type = "group", name = "Tracked Spells", order = 3, args = {} },
             },
           },
         },
       },
-      utility = ClassHUD:GetUtilityOptions(),
-      buffLinks = {
+      colors = {
         type = "group",
-        name = "Buff -> Spell Links",
-        order = 6,
+        name = "Colors",
+        order = 3,
         args = {
-          addBuffID = {
-            type = "input",
-            name = "BuffID",
+          hp = {
+            type = "color",
+            name = "Health",
             order = 1,
-            set = function(_, val) addon._newBuffID = tonumber(val) end,
-          },
-          addSpellID = {
-            type = "input",
-            name = "SpellID",
-            order = 2,
-            set = function(_, val) addon._newSpellID = tonumber(val) end,
-          },
-          add = {
-            type = "execute",
-            name = "Legg til kobling",
-            order = 3,
-            func = function()
-              if addon._newBuffID and addon._newSpellID then
-                local _, class                                        = UnitClass("player")
-                local specID                                          = GetSpecializationInfo(GetSpecialization() or 0)
-
-                db.profile.buffLinks[class]                           = db.profile.buffLinks[class] or {}
-                db.profile.buffLinks[class][specID]                   = db.profile.buffLinks[class][specID] or {}
-                db.profile.buffLinks[class][specID][addon._newBuffID] = addon._newSpellID
-
-                print("|cff00ff88ClassHUD|r La til kobling:", addon._newBuffID, "→", addon._newSpellID)
-                addon._newBuffID, addon._newSpellID = nil, nil
-                addon:BuildFramesForSpec()
-                RebuildBuffLinks(opts, db, addon)
-                LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-              end
+            get = function()
+              local c = db.profile.colors.hp
+              return c.r, c.g, c.b
+            end,
+            set = function(_, r, g, b)
+              db.profile.colors.hp = { r = r, g = g, b = b }
+              addon:UpdateHP()
             end,
           },
-          list = {
-            type = "group",
-            name = "",
+          resourceClass = {
+            type = "toggle",
+            name = "Use Class Color for Primary Resource",
+            order = 2,
+            get = function() return db.profile.colors.resourceClass end,
+            set = function(_, value)
+              db.profile.colors.resourceClass = value
+              addon:UpdatePrimaryResource()
+            end,
+          },
+          resource = {
+            type = "color",
+            name = "Primary Resource",
+            order = 3,
+            get = function()
+              local c = db.profile.colors.resource
+              return c.r, c.g, c.b
+            end,
+            set = function(_, r, g, b)
+              db.profile.colors.resource = { r = r, g = g, b = b }
+              addon:UpdatePrimaryResource()
+            end,
+            disabled = function() return db.profile.colors.resourceClass end,
+          },
+          power = {
+            type = "color",
+            name = "Special Power",
             order = 4,
-            args = {}, -- blir fylt av RebuildBuffLinks
+            get = function()
+              local c = db.profile.colors.power
+              return c.r, c.g, c.b
+            end,
+            set = function(_, r, g, b)
+              db.profile.colors.power = { r = r, g = g, b = b }
+              addon:UpdateSpecialPower()
+            end,
           },
         },
       },
-      trackedBuffs = {
+      spells = {
         type = "group",
-        name = "Tracked Buffs",
-        order = 7,
+        name = "Spells & Buffs",
+        order = 4,
         args = {
-          desc = {
-            type = "description",
-            name = "Velg hvilke buffs du ønsker å spore. Disse vises i en egen bar over Top Bar.\n",
-            order = 1,
-          },
-          addCustom = {
-            type = "input",
-            name = "Legg til BuffID manuelt",
-            desc = "Skriv inn et buffID du ønsker å tracke manuelt.",
-            order = 3,
-            set = function(_, val)
-              local newID = tonumber(val)
-              if newID then
-                local _, class                                = UnitClass("player")
-                local specID                                  = GetSpecializationInfo(GetSpecialization() or 0)
-                db.profile.trackedBuffs[class]                = db.profile.trackedBuffs[class] or {}
-                db.profile.trackedBuffs[class][specID]        = db.profile.trackedBuffs[class][specID] or {}
-                db.profile.trackedBuffs[class][specID][newID] = true
-                print("|cff00ff88ClassHUD|r La til ny tracked buff:", newID)
-                addon:BuildFramesForSpec()
-                RebuildTrackedBuffs(opts, db, addon)
-                LibStub("AceConfigRegistry-3.0"):NotifyChange("ClassHUD")
-              end
-            end,
-          },
-          list = {
+          topBar = {
             type = "group",
-            name = "Tilgjengelige Buffs",
-            inline = true,
+            name = "Top Bar Spells",
+            order = 1,
+            args = {
+              description = {
+                type = "description",
+                name = "Assign essential abilities to HUD positions.",
+                order = 1,
+              },
+              addSpell = {
+                type = "input",
+                name = "Add Spell ID",
+                order = 2,
+                width = "half",
+                get = function() return "" end,
+                set = function(_, value)
+                  local spellID = tonumber(value)
+                  if not spellID then return end
+                  addon.db.profile.utilityPlacement[spellID] = "TOP"
+                  addon:BuildFramesForSpec()
+                  BuildPlacementArgs(addon, topBarContainer, "essential", "TOP", "No essential spells reported for this spec.")
+                  NotifyOptionsChanged()
+                end,
+              },
+              list = {
+                type = "group",
+                name = "Assignments",
+                inline = true,
+                order = 3,
+                args = topBarContainer,
+              },
+            },
+          },
+          utility = {
+            type = "group",
+            name = "Utility Placement",
             order = 2,
-            args = {},
+            args = {
+              list = {
+                type = "group",
+                name = "Spells",
+                inline = true,
+                order = 1,
+                args = utilityContainer,
+              },
+            },
+          },
+          trackedBuffs = {
+            type = "group",
+            name = "Tracked Buffs & Bars",
+            order = 3,
+            args = {
+              description = {
+                type = "description",
+                name = "Configure which Blizzard tracked buffs and cooldown bars appear in the HUD.",
+                order = 1,
+              },
+              addBuff = {
+                type = "input",
+                name = "Add Buff ID",
+                order = 2,
+                width = "half",
+                get = function() return "" end,
+                set = function(_, value)
+                  local buffID = tonumber(value)
+                  if not buffID then return end
+                  local class, specID = addon:GetPlayerClassSpec()
+                  addon.db.profile.trackedBuffs[class] = addon.db.profile.trackedBuffs[class] or {}
+                  addon.db.profile.trackedBuffs[class][specID] = addon.db.profile.trackedBuffs[class][specID] or {}
+                  addon.db.profile.trackedBuffs[class][specID][buffID] = true
+                  addon:BuildTrackedBuffFrames()
+                  BuildTrackedBuffArgs(addon, trackedContainer)
+                  NotifyOptionsChanged()
+                end,
+              },
+              list = {
+                type = "group",
+                name = "Entries",
+                inline = true,
+                order = 3,
+                args = trackedContainer,
+              },
+            },
+          },
+          buffLinks = {
+            type = "group",
+            name = "Buff Links",
+            order = 4,
+            args = {
+              description = {
+                type = "description",
+                name = "Manual overrides linking a buff to a spell. These are populated automatically when possible.",
+                order = 1,
+              },
+              list = {
+                type = "group",
+                name = "Links",
+                inline = true,
+                order = 2,
+                args = linkContainer,
+              },
+              add = {
+                type = "group",
+                name = "Add New Link",
+                inline = true,
+                order = 3,
+                args = {
+                  buffID = {
+                    type = "input",
+                    name = "Buff ID",
+                    order = 1,
+                    width = "half",
+                    get = function() return optionsState.newLinkBuffID end,
+                    set = function(_, value)
+                      optionsState.newLinkBuffID = value or ""
+                    end,
+                  },
+                  spellID = {
+                    type = "input",
+                    name = "Spell ID",
+                    order = 2,
+                    width = "half",
+                    get = function() return optionsState.newLinkSpellID end,
+                    set = function(_, value)
+                      optionsState.newLinkSpellID = value or ""
+                    end,
+                  },
+                  addButton = {
+                    type = "execute",
+                    name = "Add Link",
+                    order = 3,
+                    func = function()
+                      local buffID = tonumber(optionsState.newLinkBuffID)
+                      local spellID = tonumber(optionsState.newLinkSpellID)
+                      if not (buffID and spellID) then return end
+                      local class, specID = addon:GetPlayerClassSpec()
+                      addon.db.profile.buffLinks[class] = addon.db.profile.buffLinks[class] or {}
+                      addon.db.profile.buffLinks[class][specID] = addon.db.profile.buffLinks[class][specID] or {}
+                      addon.db.profile.buffLinks[class][specID][buffID] = spellID
+                      addon:BuildFramesForSpec()
+                      BuildBuffLinkArgs(addon, linkContainer)
+                      optionsState.newLinkBuffID = ""
+                      optionsState.newLinkSpellID = ""
+                      NotifyOptionsChanged()
+                    end,
+                  },
+                },
+              },
+            },
           },
         },
-      }
-
+      },
+      snapshot = {
+        type = "group",
+        name = "Snapshot",
+        order = 5,
+        args = {
+          refresh = {
+            type = "execute",
+            name = "Refresh Snapshot",
+            order = 1,
+            func = function()
+              addon:UpdateCDMSnapshot()
+              addon:BuildFramesForSpec()
+              BuildPlacementArgs(addon, topBarContainer, "essential", "TOP", "No essential spells reported for this spec.")
+              BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN", "No utility cooldowns reported by the snapshot for this spec.")
+              BuildTrackedBuffArgs(addon, trackedContainer)
+              BuildBuffLinkArgs(addon, linkContainer)
+              NotifyOptionsChanged()
+            end,
+          },
+          note = {
+            type = "description",
+            order = 2,
+            name = "The snapshot is rebuilt automatically on login and specialization changes. Use this button if Blizzard updates the Cooldown Viewer data while you are logged in.",
+          },
+        },
+      },
     },
   }
 
-  -- Build dynamic spell groups for all bars on open
-  RebuildSpellTree(opts, db, addon, "top")
-  RebuildSpellTree(opts, db, addon, "bottom")
-  RebuildSpellTree(opts, db, addon, "left")
-  RebuildSpellTree(opts, db, addon, "right")
-  RebuildBuffLinks(opts, db, addon)
-  RebuildTrackedBuffs(opts, db, addon)
-  addon._opts = opts -- keep a stable reference for later calls
+  BuildPlacementArgs(addon, topBarContainer, "essential", "TOP", "No essential spells reported for this spec.")
+  BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN", "No utility cooldowns reported by the snapshot for this spec.")
+  BuildTrackedBuffArgs(addon, trackedContainer)
+  BuildBuffLinkArgs(addon, linkContainer)
+
   return opts
+end
+
+function ClassHUD:GetUtilityOptions()
+  local container = {}
+  BuildPlacementArgs(self, container, "utility", "HIDDEN", "No utility cooldowns reported by the snapshot for this spec.")
+  return {
+    type = "group",
+    name = "Utility Cooldowns",
+    args = container,
+  }
 end

--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -425,6 +425,7 @@ function ClassHUD_BuildOptions(addon)
   db.profile.sideBars.size = db.profile.sideBars.size or 36
   db.profile.sideBars.spacing = db.profile.sideBars.spacing or 4
   db.profile.sideBars.offset = db.profile.sideBars.offset or 6
+  db.profile.sideBars.yOffset = db.profile.sideBars.yOffset or 0
   db.profile.trackedBuffBar = db.profile.trackedBuffBar or {}
   db.profile.trackedBuffBar.perRow = db.profile.trackedBuffBar.perRow or 8
   db.profile.trackedBuffBar.spacingX = db.profile.trackedBuffBar.spacingX or 4
@@ -837,6 +838,19 @@ function ClassHUD_BuildOptions(addon)
                 get = function() return db.profile.sideBars.offset end,
                 set = function(_, value)
                   db.profile.sideBars.offset = value
+                  addon:BuildFramesForSpec()
+                end,
+              },
+              yOffset = {
+                type = "range",
+                name = "Sidebar Y-Offset",
+                order = 4,
+                min = -200,
+                max = 200,
+                step = 1,
+                get = function() return db.profile.sideBars.yOffset or 0 end,
+                set = function(_, value)
+                  db.profile.sideBars.yOffset = value
                   addon:BuildFramesForSpec()
                 end,
               },

--- a/ClassHUD_Utils.lua
+++ b/ClassHUD_Utils.lua
@@ -1,0 +1,278 @@
+-- ClassHUD_Utils.lua
+-- Shared helper utilities used across the addon.
+
+---@type ClassHUD
+local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
+
+ClassHUD._lastSpecID = ClassHUD._lastSpecID or 0
+
+local DEFAULT_TRACKED_BAR_COLOR = { r = 0.25, g = 0.65, b = 1.00, a = 1 }
+
+local function CopyColorTemplate(template)
+  return {
+    r = template.r or 1,
+    g = template.g or 1,
+    b = template.b or 1,
+    a = template.a or 1,
+  }
+end
+
+-- ---------------------------------------------------------------------------
+-- Profile helpers
+-- ---------------------------------------------------------------------------
+
+---Returns the player's class token ("MAGE", "PRIEST" ...) and specialization ID.
+---@return string classToken, number specID
+function ClassHUD:GetPlayerClassSpec()
+  local _, class = UnitClass("player")
+  local specIndex = GetSpecialization()
+  local specID = 0
+
+  if specIndex then
+    specID = GetSpecializationInfo(specIndex) or 0
+  end
+
+  if specID and specID > 0 then
+    self._lastSpecID = specID
+  elseif self._lastSpecID and self._lastSpecID > 0 then
+    specID = self._lastSpecID
+  end
+
+  return class, specID
+end
+
+---Internal helper to walk the saved variables profile tree.
+---@param create boolean|nil If true, missing tables are created on the way.
+---@param ... string Path within profile.
+---@return table|nil
+function ClassHUD:GetProfileTable(create, ...)
+  if not (self.db and self.db.profile) then return nil end
+
+  local node = self.db.profile
+  local path = { ... }
+
+  for i = 1, #path do
+    local key = path[i]
+    if type(node[key]) ~= "table" then
+      if not create then return nil end
+      node[key] = {}
+    end
+    node = node[key]
+  end
+
+  return node
+end
+
+---Convenience wrapper for accessing the cooldown snapshot storage.
+---@param create boolean|nil If true, the snapshot root is created if needed.
+---@return table|nil
+function ClassHUD:GetSnapshotRoot(create)
+  return self:GetProfileTable(create, "cdmSnapshot")
+end
+
+---Returns the snapshot table for a given class/spec combination.
+---@param class string|nil Defaults to the player's class.
+---@param specID number|nil Defaults to the player's current spec.
+---@param create boolean|nil Create the table if it does not exist.
+---@return table|nil
+function ClassHUD:GetSnapshotForSpec(class, specID, create)
+  local playerClass, playerSpec = self:GetPlayerClassSpec()
+  class = class or playerClass
+  specID = specID or playerSpec
+
+  local root = self:GetSnapshotRoot(create)
+  if not root then return nil end
+
+  if type(root[class]) ~= "table" then
+    if not create then return nil end
+    root[class] = {}
+  end
+
+  if type(root[class][specID]) ~= "table" then
+    if not create then return nil end
+    root[class][specID] = {}
+  end
+
+  return root[class][specID]
+end
+
+---Resets the snapshot table for the given class/spec.
+---@param class string|nil
+---@param specID number|nil
+function ClassHUD:ResetSnapshotFor(class, specID)
+  local snapshot = self:GetSnapshotForSpec(class, specID, true)
+  if not snapshot then return end
+  for k in pairs(snapshot) do
+    snapshot[k] = nil
+  end
+end
+
+---Returns the stored snapshot entry for a spell/buff ID.
+---@param spellID number
+---@param class string|nil
+---@param specID number|nil
+---@return table|nil
+function ClassHUD:GetSnapshotEntry(spellID, class, specID)
+  local snapshot = self:GetSnapshotForSpec(class, specID, false)
+  if not snapshot then return nil end
+  return snapshot[spellID]
+end
+
+---Returns a fresh copy of the default tracked-bar color settings.
+---@return table
+function ClassHUD:GetDefaultTrackedBarColor()
+  return CopyColorTemplate(DEFAULT_TRACKED_BAR_COLOR)
+end
+
+local function NormalizeTrackedConfigTable(config)
+  config.showIcon = not not config.showIcon
+  config.showBar = not not config.showBar
+
+  if config.barShowIcon == nil then
+    config.barShowIcon = true
+  else
+    config.barShowIcon = not not config.barShowIcon
+  end
+
+  if config.barShowTimer == nil then
+    config.barShowTimer = true
+  else
+    config.barShowTimer = not not config.barShowTimer
+  end
+
+  local color = config.barColor
+  if type(color) ~= "table" then
+    config.barColor = CopyColorTemplate(DEFAULT_TRACKED_BAR_COLOR)
+  else
+    config.barColor = {
+      r = color.r or DEFAULT_TRACKED_BAR_COLOR.r,
+      g = color.g or DEFAULT_TRACKED_BAR_COLOR.g,
+      b = color.b or DEFAULT_TRACKED_BAR_COLOR.b,
+      a = color.a or DEFAULT_TRACKED_BAR_COLOR.a,
+    }
+  end
+
+  return config
+end
+
+local function NormalizeTrackedConfig(value)
+  if type(value) == "table" then
+    return NormalizeTrackedConfigTable(value)
+  elseif type(value) == "boolean" then
+    return NormalizeTrackedConfigTable({
+      showIcon = value,
+      showBar = false,
+      barShowIcon = true,
+      barShowTimer = true,
+      barColor = CopyColorTemplate(DEFAULT_TRACKED_BAR_COLOR),
+    })
+  end
+
+  return nil
+end
+
+---Returns (and optionally creates) the configuration block for a tracked buff/bar entry.
+---@param class string|nil
+---@param specID number|nil
+---@param buffID number
+---@param create boolean|nil
+---@return table|nil
+function ClassHUD:GetTrackedEntryConfig(class, specID, buffID, create)
+  local playerClass, playerSpec = self:GetPlayerClassSpec()
+  class = class or playerClass
+  specID = specID or playerSpec
+
+  local tracked = self:GetProfileTable(create, "trackedBuffs", class, specID)
+  if not tracked then return nil end
+
+  local value = tracked[buffID]
+  local normalized = NormalizeTrackedConfig(value)
+
+  if normalized then
+    if normalized ~= value then
+      tracked[buffID] = normalized
+    end
+    return normalized
+  end
+
+  if create then
+    local fresh = NormalizeTrackedConfig(false)
+    tracked[buffID] = fresh
+    return fresh
+  end
+
+  return nil
+end
+
+---Iterates over snapshot entries for a given category and calls the handler.
+---@param category string One of "essential", "utility", "buff", "bar".
+---@param handler fun(spellID:number, entry:table, categoryData:table)
+---@param class string|nil
+---@param specID number|nil
+function ClassHUD:ForEachSnapshotEntry(category, handler, class, specID)
+  local snapshot = self:GetSnapshotForSpec(class, specID, false)
+  if not snapshot then return end
+
+  for spellID, entry in pairs(snapshot) do
+    local categories = entry.categories
+    local categoryData = categories and categories[category]
+    if categoryData then
+      handler(spellID, entry, categoryData)
+    end
+  end
+end
+
+---Checks if the Blizzard Cooldown Viewer API is currently available.
+---@return boolean
+function ClassHUD:IsCooldownViewerAvailable()
+  return C_CooldownViewer and C_CooldownViewer.IsCooldownViewerAvailable
+      and C_CooldownViewer.IsCooldownViewerAvailable()
+end
+
+-- ---------------------------------------------------------------------------
+-- Generic helpers
+-- ---------------------------------------------------------------------------
+
+---Formats a duration in seconds for compact cooldown text.
+---@param seconds number
+---@return string
+function ClassHUD.FormatSeconds(seconds)
+  if seconds >= 60 then
+    return string.format("%dm", math.ceil(seconds / 60))
+  elseif seconds >= 10 then
+    return tostring(math.floor(seconds + 0.5))
+  else
+    return string.format("%.1f", seconds)
+  end
+end
+
+local DEFAULT_AURA_UNITS = { "player", "pet", "target", "focus", "mouseover" }
+
+---Finds the first relevant aura for the given spell ID across a list of units.
+---@param spellID number
+---@param units string[]|nil
+---@return table|nil auraData, string|nil unit
+function ClassHUD:GetAuraForSpell(spellID, units)
+  if not C_UnitAuras then return nil end
+
+  units = units or DEFAULT_AURA_UNITS
+
+  if C_UnitAuras.GetPlayerAuraBySpellID then
+    local aura = C_UnitAuras.GetPlayerAuraBySpellID(spellID)
+    if aura then return aura, "player" end
+  end
+
+  if C_UnitAuras.GetAuraDataBySpellID then
+    for _, unit in ipairs(units) do
+      if unit ~= "player" and UnitExists(unit) then
+        local aura = C_UnitAuras.GetAuraDataBySpellID(unit, spellID)
+        if aura and (aura.isFromPlayer or aura.sourceUnit == "player" or aura.sourceUnit == "pet") then
+          return aura, unit
+        end
+      end
+    end
+  end
+
+  return nil
+end
+

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Built with [Ace3](https://www.wowace.com/projects/ace3) and LibSharedMedia.
 
 ## ✨ Features
 
-- Cast, HP, Resource, and Special Power bars.
-- Customizable top/bottom/left/right bars for spells.
-- Spell tracking with cooldowns, aura glow, and stack counts.
-- Suggested spells per class/spec (pre-filled).
-- Ace3 options panel (`/chud`).
+- Cast, HP, primary resource, and special power bars that adapt per class/spec.
+- Snapshot-driven spell layout sourced from Blizzard's Cooldown Viewer API.
+- Automatic glow, cooldown, and aura stack handling for tracked spells and buffs.
+- Configurable utility placement (top/bottom/left/right) with per-spec persistence.
+- Simplified Ace3 options panel (`/chud`) with snapshot refresh, tracked buff toggles, and buff→spell link editing.
 
 ---
 
@@ -26,16 +26,39 @@ Built with [Ace3](https://www.wowace.com/projects/ace3) and LibSharedMedia.
 
 ## 🛠 Usage
 
-- Open options with `/chud`
-- Add spells manually by SpellID or from suggested list
-- Supports aura glow, aura stack counts, and icon swap on aura active
-- Fully movable and resizable bars
+- Open options with `/chud`.
+- Refresh the Blizzard snapshot (if needed) from **Snapshot → Refresh Snapshot**.
+- Configure which utility cooldowns appear on each bar under **Spells & Buffs → Utility Placement**.
+- Toggle tracked buffs and manage buff links under **Spells & Buffs**.
+- Move the anchor by unlocking the frame in **General**.
+
+## 🗂 Architecture
+
+The addon is organised into lightweight modules:
+
+| File | Responsibility |
+| ---- | -------------- |
+| `ClassHUD.lua` | Core addon lifecycle, events, saved variables, snapshot management. |
+| `ClassHUD_Utils.lua` | Shared helpers for profile access, snapshot lookup, formatting, and aura search. |
+| `ClassHUD_Bars.lua` | Anchor frame creation, cast/resource/health bar layout and updates. |
+| `ClassHUD_Classbar.lua` | Class-specific special power/segment handling. |
+| `ClassHUD_Spells.lua` | Snapshot-driven spell frame creation, cooldown/aura updates, tracked buff bar. |
+| `ClassHUD_Options.lua` | Ace3 configuration rebuilt around the snapshot cache. |
+| `ClassHUD_SpellSuggestions.lua` | Optional pre-filled spell suggestions (data only). |
+
+### Suggested future structure
+
+To keep modules focused as the addon grows, consider grouping files under folders:
+
+- `core/` for bootstrap (`ClassHUD.lua`, `ClassHUD_Utils.lua`).
+- `ui/` for bars, spell frames, and any future UI widgets.
+- `config/` for options and suggestion data.
+- `modules/` for optional trackers (e.g., interrupt tracker, class-specific extras).
 
 ## 🦴 Todo
 
-- [ ] - Clean up the Options. Better the flow
-- [ ] - Add sound notification
-- [ ] - Add more classes
+- [ ] Add optional sound notifications.
+- [ ] Extend spell suggestions for remaining specs.
 
 ---
 


### PR DESCRIPTION
## Summary
- capture Blizzard tracked bar snapshot entries and position a shared tracked container between the cast bar and spell icons so layout shifts automatically
- add tracked bar configuration helpers plus bar/icon frame builders to render cooldown bars alongside tracked buff icons
- refresh the options UI with per-entry buff/bar controls, tracked bar height slider, and improved debug reporting of configured display modes

## Testing
- `luac -p ClassHUD.lua ClassHUD_Bars.lua ClassHUD_Options.lua ClassHUD_Spells.lua ClassHUD_Utils.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cbdea078f4832182701738377c52a4