### PR TITLE
Refactor to use Blizzard cooldown viewer and new buff system

### DIFF
--- a/ClassHUD_Bars.lua
+++ b/ClassHUD_Bars.lua
@@ -26,11 +26,11 @@ function ClassHUD:CreateCastBar()
   b.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
 
   b.spell = b:CreateFontString(nil, "OVERLAY")
-  b.spell:SetFont(self:FetchFont(12))
+  b.spell:SetFont(self:FetchFont(self.db.profile.spellFontSize or 12))
   b.spell:SetPoint("LEFT", b.icon, "RIGHT", 4, 0)
 
   b.time = b:CreateFontString(nil, "OVERLAY")
-  b.time:SetFont(self:FetchFont(12))
+  b.time:SetFont(self:FetchFont(self.db.profile.spellFontSize or 12))
   b.time:SetPoint("RIGHT", b, "RIGHT", -3, 0)
 
   UI.cast = b
@@ -73,8 +73,8 @@ function ClassHUD:ApplyBarSkins()
     end
   end
   if UI.cast then
-    UI.cast.spell:SetFont(self:FetchFont(12))
-    UI.cast.time:SetFont(self:FetchFont(12))
+    UI.cast.spell:SetFont(self:FetchFont(self.db.profile.spellFontSize or 12))
+    UI.cast.time:SetFont(self:FetchFont(self.db.profile.spellFontSize or 12))
   end
   if UI.hp then UI.hp.text:SetFont(self:FetchFont(12)) end
   if UI.resource then UI.resource.text:SetFont(self:FetchFont(12)) end

--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -1,556 +1,171 @@
--- ClassHUD_Options.lua
--- Rebuilt, snapshot-driven options UI
-
----@type ClassHUD
 local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
 
-local ACR = LibStub("AceConfigRegistry-3.0")
+local ACR = LibStub("AceConfigRegistry-3.0", true)
 local LSM = LibStub("LibSharedMedia-3.0", true)
+local AceDBOptions = LibStub("AceDBOptions-3.0", true)
 
-local PLACEMENTS = {
-  HIDDEN = "Hidden",
-  TOP = "Top Bar",
-  BOTTOM = "Bottom Bar",
-  LEFT = "Left Side",
-  RIGHT = "Right Side",
-}
+local copyTable = CopyTable
+if type(copyTable) ~= "function" then
+  copyTable = function(tbl)
+    local result = {}
+    if type(tbl) == "table" then
+      for k, v in pairs(tbl) do
+        result[k] = v
+      end
+    end
+    return result
+  end
+end
 
 local optionsState = {
-  newLinkBuffID = "",
-  newLinkSpellID = "",
+  newCustomBuff = "",
 }
 
 local function NotifyOptionsChanged()
-  if ACR then ACR:NotifyChange("ClassHUD") end
+  if ACR then
+    ACR:NotifyChange("ClassHUD")
+  end
 end
 
-local function SortEntries(snapshot, category)
-  if not snapshot then return {} end
-  local list = {}
-  for spellID, entry in pairs(snapshot) do
-    local cat = entry.categories and entry.categories[category]
-    if cat then
-      table.insert(list, { spellID = spellID, entry = entry, order = (cat.order or math.huge) })
-    end
-  end
-  table.sort(list, function(a, b)
-    if a.order == b.order then
-      return (a.entry.name or "") < (b.entry.name or "")
-    end
-    return a.order < b.order
-  end)
-  return list
+local function FormatSpellLabel(spellID)
+  local info = C_Spell.GetSpellInfo(spellID)
+  local icon = info and info.iconID or 134400
+  local name = info and info.name or ("Spell " .. spellID)
+  return string.format("|T%d:16|t %s (%d)", icon, name, spellID)
 end
 
--- Bygger Top Bar Spells-editoren inline (uten å lage ny venstremeny-node)
-local function BuildTopBarSpellsEditor(addon, container)
-  for k in pairs(container) do container[k] = nil end
+local function BuildTrackedEntries(addon)
+  local entries = {}
+  local index = 1
+  local seen = {}
 
-  local class, specID = addon:GetPlayerClassSpec()
+  for _, entry in ipairs(addon:BuildTrackedBuffsFromBlizzard()) do
+    local copy = copyTable(entry)
+    copy.order = index
+    copy.category = "Tracked Buff"
+    entries[#entries + 1] = copy
+    seen[copy.buffID] = copy
+    index = index + 1
+  end
 
-  addon.db.profile.utilityPlacement[class] = addon.db.profile.utilityPlacement[class] or {}
-  addon.db.profile.utilityPlacement[class][specID] = addon.db.profile.utilityPlacement[class][specID] or {}
-  local placements = addon.db.profile.utilityPlacement[class][specID]
-
-  local snapshot = addon:GetSnapshotForSpec(class, specID, false)
-  local seen, list = {}, {}
-
-  -- 1) Ta med alle spells manuelt lagt i Top Bar
-  for spellID, placement in pairs(placements) do
-    if placement == "TOP" then
-      table.insert(list, spellID)
-      seen[spellID] = true
+  for _, entry in ipairs(addon:BuildTrackedBarsAsBuffs()) do
+    local existing = seen[entry.buffID]
+    if existing then
+      existing.isTrackedBar = true
+      existing.category = existing.category .. " + Tracked Bar"
+      existing.cooldownID = existing.cooldownID or entry.cooldownID
+    else
+      local copy = copyTable(entry)
+      copy.order = index
+      copy.category = "Tracked Bar"
+      entries[#entries + 1] = copy
+      seen[copy.buffID] = copy
+      index = index + 1
     end
   end
 
-  -- 2) Ta med alle essential-spells fra snapshot
-  if snapshot then
-    for spellID, entry in pairs(snapshot) do
-      if entry.categories and entry.categories.essential then
-        if not seen[spellID] then
-          table.insert(list, spellID)
-          seen[spellID] = true
-        end
-      end
+  table.sort(entries, function(a, b)
+    if a.order ~= b.order then
+      return a.order < b.order
     end
-  end
-  table.sort(list, function(a, b)
-    local ia, ib = C_Spell.GetSpellInfo(a), C_Spell.GetSpellInfo(b)
-    local na, nb = (ia and ia.name) or tostring(a), (ib and ib.name) or tostring(b)
-    if na == nb then return a < b else return na < nb end
+    return (a.name or "") < (b.name or "")
   end)
 
+  return entries
+end
+
+local function BuildBlizzardTrackedArgs(addon)
+  local args = {}
+  local entries = BuildTrackedEntries(addon)
   local order = 1
-  if #list == 0 then
-    container.empty = {
+
+  if #entries == 0 then
+    args.none = {
       type = "description",
-      name = "No spells on the Top Bar yet. Use 'Add Spell ID' to add one.",
+      name = "Blizzard has no tracked buffs for this specialization.",
       order = order,
     }
-    return
+    return args
   end
 
-  -- Build group per spell (inline = true => ingen underkategori i venstremenyen)
-  for _, spellID in ipairs(list) do
-    local s = C_Spell.GetSpellInfo(spellID)
-    local icon = s and s.iconID and ("|T" .. s.iconID .. ":16|t ") or ""
-    local name = (s and s.name) or ("Spell " .. spellID)
-
-    -- Linked buffs for denne spellen (vis som klikk-for-å-fjerne)
-    local linkedArgs, idx = {}, 1
-    local links = addon.db.profile.buffLinks[class] and addon.db.profile.buffLinks[class][specID]
-    if links then
-      local buffIDs = {}
-      for buffID, linkedSpellID in pairs(links) do
-        if linkedSpellID == spellID then table.insert(buffIDs, buffID) end
-      end
-      table.sort(buffIDs)
-      for _, buffID in ipairs(buffIDs) do
-        local b = C_Spell.GetSpellInfo(buffID)
-        local bi = b and b.iconID and ("|T" .. b.iconID .. ":16|t ") or ""
-        local bn = (b and b.name) or ("Buff " .. buffID)
-        linkedArgs["b" .. buffID] = {
-          type  = "execute",
-          name  = bi .. bn .. " (" .. buffID .. ")",
-          desc  = "Click to remove this link",
-          order = idx,
-          func  = function()
-            addon.db.profile.buffLinks[class][specID][buffID] = nil
-            BuildTopBarSpellsEditor(addon, container)
-            addon:BuildFramesForSpec()
-            local ACR = LibStub("AceConfigRegistry-3.0", true)
-            if ACR then ACR:NotifyChange("ClassHUD") end
-          end,
-        }
-        idx = idx + 1
-      end
-    end
-    if idx == 1 then
-      linkedArgs.none = { type = "description", name = "No linked buffs yet.", order = 1 }
+  for _, entry in ipairs(entries) do
+    local key = "tracked" .. entry.buffID
+    local label = FormatSpellLabel(entry.buffID)
+    if entry.category then
+      label = string.format("%s |cff8080ff[%s]|r", label, entry.category)
     end
 
-    container["spell" .. spellID] = {
-      type   = "group",
-      name   = icon .. name .. " (" .. spellID .. ")",
-      inline = true,
-      order  = order,
-      args   = {
-        addBuff = {
-          type  = "input",
-          name  = "Add Buff ID",
-          order = 1,
-          width = "half",
-          get   = function() return "" end,
-          set   = function(_, val)
-            local buffID = tonumber(val); if not buffID then return end
-            addon.db.profile.buffLinks[class] = addon.db.profile.buffLinks[class] or {}
-            addon.db.profile.buffLinks[class][specID] = addon.db.profile.buffLinks[class][specID] or {}
-            addon.db.profile.buffLinks[class][specID][buffID] = spellID
-            BuildTopBarSpellsEditor(addon, container)
-            addon:BuildFramesForSpec()
-            local ACR = LibStub("AceConfigRegistry-3.0", true)
-            if ACR then ACR:NotifyChange("ClassHUD") end
-          end,
-        },
-        linked = {
-          type   = "group",
-          name   = "Linked Buffs",
-          order  = 2,
-          inline = true,
-          args   = linkedArgs,
-        },
-        removeSpell = {
-          type    = "execute",
-          name    = "Remove Spell",
-          confirm = true,
-          order   = 99,
-          func    = function()
-            -- Fjern selve spellen fra Top Bar
-            addon.db.profile.utilityPlacement[class][specID][spellID] = nil
-            -- Fjern alle buff-links som pekte på den
-            local bl = addon.db.profile.buffLinks[class] and addon.db.profile.buffLinks[class][specID]
-            if bl then
-              for bid, sid in pairs(bl) do
-                if sid == spellID then bl[bid] = nil end
-              end
-            end
-            BuildTopBarSpellsEditor(addon, container)
-            addon:BuildFramesForSpec()
-            local ACR = LibStub("AceConfigRegistry-3.0", true)
-            if ACR then ACR:NotifyChange("ClassHUD") end
-          end,
-        },
-      },
-    }
-    order = order + 1
-  end
-end
-
-
-local function BuildPlacementArgs(addon, container, category, defaultPlacement, emptyText)
-  for k in pairs(container) do container[k] = nil end
-
-  local class, specID = addon:GetPlayerClassSpec()
-  addon.db.profile.utilityPlacement[class] = addon.db.profile.utilityPlacement[class] or {}
-  addon.db.profile.utilityPlacement[class][specID] = addon.db.profile.utilityPlacement[class][specID] or {}
-
-  local class, specID = addon:GetPlayerClassSpec()
-  addon.db.profile.utilityPlacement[class] = addon.db.profile.utilityPlacement[class] or {}
-  addon.db.profile.utilityPlacement[class][specID] = addon.db.profile.utilityPlacement[class][specID] or {}
-
-  local placements = addon.db.profile.utilityPlacement[class][specID]
-
-
-  local snapshot = addon:GetSnapshotForSpec(nil, nil, false)
-  local list = SortEntries(snapshot, category)
-  local order = 1
-  local added = {}
-
-  local function addOption(spellID, entry)
-    added[spellID] = true
-
-    local iconID = entry and entry.iconID
-    local name = entry and entry.name
-
-    if not name then
-      local info = C_Spell.GetSpellInfo(spellID)
-      iconID = iconID or (info and info.iconID)
-      name = info and info.name or ("Spell " .. spellID)
-    end
-
-    local icon = iconID and ("|T" .. iconID .. ":16|t ") or ""
-
-    -- Sjekk om noen buffLinks peker på denne spellen
-    local class, specID = addon:GetPlayerClassSpec()
-    local linkedBuffs = {}
-    if addon.db.profile.buffLinks[class] and addon.db.profile.buffLinks[class][specID] then
-      for buffID, linkedSpellID in pairs(addon.db.profile.buffLinks[class][specID]) do
-        if linkedSpellID == spellID then
-          local buffInfo = C_Spell.GetSpellInfo(buffID)
-          table.insert(linkedBuffs, (buffInfo and buffInfo.name) or ("Buff " .. buffID))
-        end
-      end
-    end
-
-    local linkNote
-    if #linkedBuffs > 0 then
-      linkNote = "|cff00ff00Linked Buffs:|r " .. table.concat(linkedBuffs, ", ")
-    end
-
-    container["spell" .. spellID] = {
-      type = "select",
-      name = icon .. name .. " (" .. spellID .. ")",
-      desc = linkNote, -- 👈 viser link-informasjon i tooltip
+    args[key] = {
+      type = "toggle",
+      name = label,
+      desc = entry.snapshot and entry.snapshot.desc or nil,
+      width = "full",
       order = order,
-      values = PLACEMENTS,
       get = function()
-        return placements[spellID] or defaultPlacement
+        return not addon:IsTrackedBuffHidden(entry.buffID)
       end,
       set = function(_, value)
-        if value == defaultPlacement then
-          placements[spellID] = nil
-        else
-          placements[spellID] = value
-        end
-        addon:BuildFramesForSpec()
-        BuildPlacementArgs(addon, container, category, defaultPlacement, emptyText)
+        addon:SetTrackedBuffHidden(entry.buffID, not value)
+        addon:BuildTrackedBuffFrames()
+        addon:RefreshRegisteredOptions()
         NotifyOptionsChanged()
       end,
     }
 
-
     order = order + 1
   end
 
-  for _, item in ipairs(list) do
-    addOption(item.spellID, item.entry)
-  end
-
-  if category == "essential" then
-    for spellID, placement in pairs(placements) do
-      if placement == "TOP" and not added[spellID] then
-        local entry = snapshot and snapshot[spellID]
-        addOption(spellID, entry)
-      end
-    end
-  end
-
-  if category == "utility" then
-    for spellID, _ in pairs(placements) do
-      if not added[spellID] then
-        local entry = snapshot and snapshot[spellID] -- kan være nil
-        addOption(spellID, entry)
-      end
-    end
-  end
-
-  if order == 1 then
-    container.empty = {
-      type = "description",
-      name = emptyText or "No entries available for this category.",
-      order = order,
-    }
-  end
+  return args
 end
 
-local function BuildTrackedBuffArgs(addon, container)
-  for k in pairs(container) do container[k] = nil end
-
-  local class, specID = addon:GetPlayerClassSpec()
-  local snapshot = addon:GetSnapshotForSpec(class, specID, false)
-
-  addon.db.profile.trackedBuffs[class] = addon.db.profile.trackedBuffs[class] or {}
-  addon.db.profile.trackedBuffs[class][specID] = addon.db.profile.trackedBuffs[class][specID] or {}
-
-  local tracked = addon.db.profile.trackedBuffs[class][specID]
-
-  local entries = {}
-
-  if snapshot then
-    for spellID, entry in pairs(snapshot) do
-      local categories = entry.categories
-      local hasBuff = categories and categories.buff
-      local hasBar = categories and categories.bar
-      if hasBuff or hasBar then
-        local order = math.huge
-        if hasBuff and hasBuff.order then order = math.min(order, hasBuff.order) end
-        if hasBar and hasBar.order then order = math.min(order, hasBar.order) end
-
-        local icon = entry.iconID and ("|T" .. entry.iconID .. ":16|t ") or ""
-        local name = entry.name or C_Spell.GetSpellName(spellID) or ("Spell " .. spellID)
-
-        entries[spellID] = {
-          buffID = spellID,
-          entry = entry,
-          icon = icon,
-          name = name,
-          hasBuff = hasBuff and true or false,
-          hasBar = hasBar and true or false,
-          order = order,
-        }
-      end
-    end
-  end
-
-  for buffID in pairs(tracked) do
-    if not entries[buffID] then
-      local info = C_Spell.GetSpellInfo(buffID)
-      entries[buffID] = {
-        buffID = buffID,
-        entry = nil,
-        icon = info and info.iconID and ("|T" .. info.iconID .. ":16|t ") or "",
-        name = info and info.name or ("Spell " .. buffID),
-        hasBuff = true,
-        hasBar = false,
-        order = math.huge,
-      }
-    end
-  end
-
-  local list = {}
-  for _, data in pairs(entries) do
-    table.insert(list, data)
-  end
-
-  table.sort(list, function(a, b)
-    if a.order == b.order then
-      return a.name < b.name
-    end
-    return a.order < b.order
-  end)
+local function BuildCustomTrackedArgs(addon)
+  local args = {}
+  local list = addon:GetCustomTrackedBuffList()
+  local order = 1
 
   if #list == 0 then
-    container.empty = {
+    args.none = {
       type = "description",
-      name = "No tracked buffs or bars available for this specialization.",
-      order = 1,
+      name = "No custom buffs configured.",
+      order = order,
     }
-    return
+    return args
   end
 
-  local order = 1
-  for _, data in ipairs(list) do
-    local buffID = data.buffID
-    local header = string.format("%s%s (%d)", data.icon or "", data.name or ("Spell " .. buffID), buffID)
+  for _, spellID in ipairs(list) do
+    local label = FormatSpellLabel(spellID)
+    local key = "custom" .. spellID
 
-    local function getConfig(create)
-      return addon:GetTrackedEntryConfig(class, specID, buffID, create)
-    end
-
-    container["buff" .. buffID] = {
+    args[key] = {
       type = "group",
-      name = header,
+      name = label,
       inline = true,
       order = order,
       args = {
-        showIcon = {
-          type = "toggle",
-          name = "Show as Icon",
-          order = 1,
-          get = function()
-            local cfg = getConfig(false)
-            return cfg and cfg.showIcon or false
-          end,
-          set = function(_, value)
-            local cfg = getConfig(true)
-            cfg.showIcon = not not value
-            addon:BuildTrackedBuffFrames()
-            BuildTrackedBuffArgs(addon, container)
-            NotifyOptionsChanged()
-          end,
-        },
-        barShowIcon = {
+        enabled = {
           type = "toggle",
           name = "Show Icon",
-          order = 3,
-          hidden = function()
-            local cfg = getConfig(false)
-            return not (data.hasBar and cfg and cfg.showBar)
-          end,
-          get = function()
-            local cfg = getConfig(false)
-            return not cfg or cfg.barShowIcon ~= false
-          end,
-          set = function(_, value)
-            local cfg = getConfig(true)
-            cfg.barShowIcon = not not value
-            addon:BuildTrackedBuffFrames()
-            NotifyOptionsChanged()
-          end,
-        },
-        barColor = {
-          type = "color",
-          name = "Bar Color",
-          order = 4,
-          hasAlpha = true,
-          hidden = function()
-            local cfg = getConfig(false)
-            return not (data.hasBar and cfg and cfg.showBar)
-          end,
-          get = function()
-            local cfg = getConfig(false)
-            local color = (cfg and cfg.barColor) or addon:GetDefaultTrackedBarColor()
-            return color.r, color.g, color.b, color.a or 1
-          end,
-          set = function(_, r, g, b, a)
-            local cfg = getConfig(true)
-            cfg.barColor = { r = r, g = g, b = b, a = a or 1 }
-            addon:BuildTrackedBuffFrames()
-            NotifyOptionsChanged()
-          end,
-        },
-        barTimer = {
-          type = "toggle",
-          name = "Show Timer",
-          order = 5,
-          hidden = function()
-            local cfg = getConfig(false)
-            return not (data.hasBar and cfg and cfg.showBar)
-          end,
-          get = function()
-            local cfg = getConfig(false)
-            return not cfg or cfg.barShowTimer ~= false
-          end,
-          set = function(_, value)
-            local cfg = getConfig(true)
-            cfg.barShowTimer = not not value
-            addon:BuildTrackedBuffFrames()
-            NotifyOptionsChanged()
-          end,
-        },
-      },
-    }
-
-    order = order + 1
-  end
-end
-
-local function BuildBuffLinkArgs(addon, container)
-  for k in pairs(container) do container[k] = nil end
-
-  local class, specID = addon:GetPlayerClassSpec()
-  addon.db.profile.buffLinks[class] = addon.db.profile.buffLinks[class] or {}
-  addon.db.profile.buffLinks[class][specID] = addon.db.profile.buffLinks[class][specID] or {}
-
-  local links = addon.db.profile.buffLinks[class][specID]
-  local order = 1
-
-  if not next(links) then
-    container.empty = {
-      type = "description",
-      name =
-      "No manual links stored for this spec. They are created automatically when buffs reference spells in their description.",
-      order = order,
-    }
-    return
-  end
-
-  local sorted = {}
-  for buffID, spellID in pairs(links) do
-    table.insert(sorted, { buffID = buffID, spellID = spellID })
-  end
-  table.sort(sorted, function(a, b) return a.buffID < b.buffID end)
-
-  for _, map in ipairs(sorted) do
-    local buffInfo = C_Spell.GetSpellInfo(map.buffID)
-    local spellInfo = C_Spell.GetSpellInfo(map.spellID)
-    local name = string.format("|T%d:16|t %s (%d) → |T%d:16|t %s (%d)",
-      buffInfo and buffInfo.iconID or 134400,
-      buffInfo and buffInfo.name or "Buff",
-      map.buffID,
-      spellInfo and spellInfo.iconID or 134400,
-      spellInfo and spellInfo.name or "Spell",
-      map.spellID)
-
-    container["link" .. map.buffID] = {
-      type = "group",
-      name = name,
-      inline = true,
-      order = order,
-      args = {
-        buff = {
-          type = "input",
-          name = "Buff ID",
-          width = "half",
           order = 1,
-          get = function() return tostring(map.buffID) end,
-          set = function(_, value)
-            local newID = tonumber(value)
-            if newID and newID ~= map.buffID then
-              local current = addon.db.profile.buffLinks[class][specID][map.buffID]
-              addon.db.profile.buffLinks[class][specID][map.buffID] = nil
-              addon.db.profile.buffLinks[class][specID][newID] = current
-              addon:BuildFramesForSpec()
-              BuildBuffLinkArgs(addon, container)
-              NotifyOptionsChanged()
-            end
-          end,
-        },
-        spell = {
-          type = "input",
-          name = "Spell ID",
           width = "half",
-          order = 2,
-          get = function() return tostring(map.spellID) end,
+          get = function()
+            return not addon:IsTrackedBuffHidden(spellID)
+          end,
           set = function(_, value)
-            local newID = tonumber(value)
-            if newID then
-              addon.db.profile.buffLinks[class][specID][map.buffID] = newID
-              addon:BuildFramesForSpec()
-              BuildBuffLinkArgs(addon, container)
-              NotifyOptionsChanged()
-            end
+            addon:SetTrackedBuffHidden(spellID, not value)
+            addon:BuildTrackedBuffFrames()
+            addon:RefreshRegisteredOptions()
+            NotifyOptionsChanged()
           end,
         },
         remove = {
           type = "execute",
           name = "Remove",
-          confirm = true,
-          order = 3,
+          order = 2,
           func = function()
-            addon.db.profile.buffLinks[class][specID][map.buffID] = nil
-            addon:BuildFramesForSpec()
-            BuildBuffLinkArgs(addon, container)
+            addon:RemoveCustomTrackedBuff(spellID)
+            addon:SetTrackedBuffHidden(spellID, false)
+            addon:BuildTrackedBuffFrames()
+            addon:RefreshRegisteredOptions()
             NotifyOptionsChanged()
           end,
         },
@@ -559,151 +174,320 @@ local function BuildBuffLinkArgs(addon, container)
 
     order = order + 1
   end
+
+  return args
 end
 
-function ClassHUD_BuildOptions(addon)
-  local db = addon.db
-
-  db.profile.textures = db.profile.textures or { bar = "Blizzard", font = "Friz Quadrata TT" }
-  db.profile.show = db.profile.show or { cast = true, hp = true, resource = true, power = true, buffs = true }
-  db.profile.height = db.profile.height or { cast = 18, hp = 14, resource = 14, power = 14 }
-  db.profile.colors = db.profile.colors or {
-    hp = { r = 0.10, g = 0.80, b = 0.10 },
-    resourceClass = true,
-    resource = { r = 0.00, g = 0.55, b = 1.00 },
-    power = { r = 1.00, g = 0.85, b = 0.10 },
-  }
-  db.profile.position = db.profile.position or { x = 0, y = -50 }
-  db.profile.position.x = db.profile.position.x or 0
-  db.profile.position.y = db.profile.position.y or -50
-  db.profile.topBar = db.profile.topBar or {}
-  db.profile.topBar.perRow = db.profile.topBar.perRow or 8
-  db.profile.topBar.spacingX = db.profile.topBar.spacingX or 4
-  db.profile.topBar.spacingY = db.profile.topBar.spacingY or 4
-  db.profile.topBar.yOffset = db.profile.topBar.yOffset or 0
-  db.profile.topBar.grow = db.profile.topBar.grow or "UP"
-  db.profile.bottomBar = db.profile.bottomBar or {}
-  db.profile.bottomBar.perRow = db.profile.bottomBar.perRow or 8
-  db.profile.bottomBar.spacingX = db.profile.bottomBar.spacingX or 4
-  db.profile.bottomBar.spacingY = db.profile.bottomBar.spacingY or 4
-  db.profile.bottomBar.yOffset = db.profile.bottomBar.yOffset or 0
-  db.profile.sideBars = db.profile.sideBars or {}
-  db.profile.sideBars.size = db.profile.sideBars.size or 36
-  db.profile.sideBars.spacing = db.profile.sideBars.spacing or 4
-  db.profile.sideBars.offset = db.profile.sideBars.offset or 6
-  db.profile.sideBars.yOffset = db.profile.sideBars.yOffset or 0
-  db.profile.trackedBuffBar = db.profile.trackedBuffBar or {}
-  db.profile.trackedBuffBar.perRow = db.profile.trackedBuffBar.perRow or 8
-  db.profile.trackedBuffBar.spacingX = db.profile.trackedBuffBar.spacingX or 4
-  db.profile.trackedBuffBar.spacingY = db.profile.trackedBuffBar.spacingY or 4
-  db.profile.trackedBuffBar.yOffset = db.profile.trackedBuffBar.yOffset or 4
-  db.profile.trackedBuffBar.align = db.profile.trackedBuffBar.align or "CENTER"
-  db.profile.trackedBuffBar.height = db.profile.trackedBuffBar.height or 16
-  db.profile.utilityPlacement = db.profile.utilityPlacement or {}
-  db.profile.trackedBuffs = db.profile.trackedBuffs or {}
-  db.profile.buffLinks = db.profile.buffLinks or {}
-
-  local topBarEditorContainer = {}
-  local utilityContainer = {}
-  local trackedContainer = {}
-  local linkContainer = {}
-
-  local opts = {
+local function BuildTrackedGroup(addon)
+  local db = addon.db.profile
+  return {
     type = "group",
-    name = "ClassHUD",
-    childGroups = "tab",
+    name = "Tracked Buffs",
+    order = 2,
     args = {
-      general = {
-        type = "group",
-        name = "General",
+      enabled = {
+        type = "toggle",
+        name = "Enable Tracked Buff Icons",
         order = 1,
+        width = "full",
+        get = function() return db.show.buffs end,
+        set = function(_, value)
+          db.show.buffs = value
+          addon:BuildTrackedBuffFrames()
+        end,
+      },
+      layout = {
+        type = "group",
+        name = "Layout",
+        inline = true,
+        order = 2,
         args = {
-          locked = {
-            type = "toggle",
-            name = "Lock Frame",
+          perRow = {
+            type = "range",
+            name = "Icons per Row",
+            min = 1,
+            max = 12,
+            step = 1,
             order = 1,
-            get = function() return db.profile.locked end,
+            get = function() return db.trackedBuffBar.perRow or 8 end,
             set = function(_, value)
-              db.profile.locked = value
+              db.trackedBuffBar.perRow = value
+              addon:BuildTrackedBuffFrames()
             end,
           },
+          spacingX = {
+            type = "range",
+            name = "Horizontal Spacing",
+            min = 0,
+            max = 20,
+            step = 1,
+            order = 2,
+            get = function() return db.trackedBuffBar.spacingX or 4 end,
+            set = function(_, value)
+              db.trackedBuffBar.spacingX = value
+              addon:BuildTrackedBuffFrames()
+            end,
+          },
+          spacingY = {
+            type = "range",
+            name = "Vertical Spacing",
+            min = 0,
+            max = 20,
+            step = 1,
+            order = 3,
+            get = function() return db.trackedBuffBar.spacingY or 4 end,
+            set = function(_, value)
+              db.trackedBuffBar.spacingY = value
+              addon:BuildTrackedBuffFrames()
+            end,
+          },
+          align = {
+            type = "select",
+            name = "Row Alignment",
+            order = 4,
+            values = {
+              LEFT = "Left",
+              CENTER = "Center",
+              RIGHT = "Right",
+            },
+            style = "dropdown",
+            get = function() return db.trackedBuffBar.align or "CENTER" end,
+            set = function(_, value)
+              db.trackedBuffBar.align = value
+              addon:BuildTrackedBuffFrames()
+            end,
+          },
+          offsetX = {
+            type = "range",
+            name = "Horizontal Offset",
+            min = -200,
+            max = 200,
+            step = 1,
+            order = 5,
+            get = function() return db.trackedBuffBar.offsetX or 0 end,
+            set = function(_, value)
+              db.trackedBuffBar.offsetX = value
+              addon:BuildTrackedBuffFrames()
+            end,
+          },
+          offsetY = {
+            type = "range",
+            name = "Vertical Offset",
+            min = -200,
+            max = 200,
+            step = 1,
+            order = 6,
+            get = function() return db.trackedBuffBar.offsetY or 8 end,
+            set = function(_, value)
+              db.trackedBuffBar.offsetY = value
+              addon:BuildTrackedBuffFrames()
+            end,
+          },
+          fontSize = {
+            type = "range",
+            name = "Font Size",
+            min = 8,
+            max = 24,
+            step = 1,
+            order = 7,
+            get = function() return db.buffFontSize or 12 end,
+            set = function(_, value)
+              db.buffFontSize = value
+              addon:BuildTrackedBuffFrames()
+            end,
+          },
+        },
+      },
+      blizzard = {
+        type = "group",
+        name = "Blizzard Tracked Buffs",
+        order = 3,
+        args = BuildBlizzardTrackedArgs(addon),
+      },
+      custom = {
+        type = "group",
+        name = "Custom Buffs",
+        order = 4,
+        args = {
+          add = {
+            type = "input",
+            name = "Add Spell ID",
+            order = 1,
+            width = "half",
+            get = function()
+              return optionsState.newCustomBuff
+            end,
+            set = function(_, value)
+              optionsState.newCustomBuff = ""
+              local spellID = tonumber(value)
+              if not spellID then return end
+              local info = C_Spell.GetSpellInfo(spellID)
+            if not info then return end
+            addon:AddCustomTrackedBuff(spellID)
+            addon:SetTrackedBuffHidden(spellID, false)
+            addon:BuildTrackedBuffFrames()
+            addon:RefreshRegisteredOptions()
+            NotifyOptionsChanged()
+          end,
+          },
+          list = {
+            type = "group",
+            name = "Configured Buffs",
+            order = 2,
+            inline = false,
+            args = BuildCustomTrackedArgs(addon),
+          },
+        },
+      },
+    },
+  }
+end
+
+local function BuildGeneralGroup(addon)
+  local db = addon.db.profile
+  return {
+    type = "group",
+    name = "General",
+    order = 1,
+    args = {
+      locked = {
+        type = "toggle",
+        name = "Lock Position",
+        order = 1,
+        get = function() return db.locked end,
+        set = function(_, value)
+          db.locked = value
+        end,
+      },
+      position = {
+        type = "group",
+        name = "Anchor Offset",
+        inline = true,
+        order = 2,
+        args = {
+          posX = {
+            type = "range",
+            name = "Horizontal",
+            min = -400,
+            max = 400,
+            step = 1,
+            order = 1,
+            get = function() return db.position.x or 0 end,
+            set = function(_, value)
+              db.position.x = value
+              addon:ApplyAnchorPosition()
+            end,
+          },
+          posY = {
+            type = "range",
+            name = "Vertical",
+            min = -400,
+            max = 400,
+            step = 1,
+            order = 2,
+            get = function() return db.position.y or -24 end,
+            set = function(_, value)
+              db.position.y = value
+              addon:ApplyAnchorPosition()
+            end,
+          },
+        },
+      },
+      layout = {
+        type = "group",
+        name = "Layout",
+        inline = true,
+        order = 3,
+        args = {
           width = {
             type = "range",
             name = "Bar Width",
-            min = 200,
-            max = 600,
+            min = 150,
+            max = 400,
             step = 1,
-            order = 2,
-            get = function() return db.profile.width end,
+            order = 1,
+            get = function() return db.width end,
             set = function(_, value)
-              db.profile.width = value
+              db.width = value
               addon:FullUpdate()
-              addon:BuildFramesForSpec()
-            end,
-          },
-          positionX = {
-            type = "range",
-            name = "Position X",
-            order = 3,
-            min = -1000,
-            max = 1000,
-            step = 1,
-            get = function() return db.profile.position.x or 0 end,
-            set = function(_, value)
-              db.profile.position.x = value
-              addon:ApplyAnchorPosition()
-            end,
-          },
-          positionY = {
-            type = "range",
-            name = "Position Y",
-            order = 4,
-            min = -1000,
-            max = 1000,
-            step = 1,
-            get = function() return db.profile.position.y or 0 end,
-            set = function(_, value)
-              db.profile.position.y = value
-              addon:ApplyAnchorPosition()
             end,
           },
           spacing = {
             type = "range",
-            name = "Bar Spacing",
+            name = "Vertical Spacing",
+            min = 0,
+            max = 20,
+            step = 1,
+            order = 2,
+            get = function() return db.spacing or 2 end,
+            set = function(_, value)
+              db.spacing = value
+              addon:FullUpdate()
+            end,
+          },
+          powerSpacing = {
+            type = "range",
+            name = "Power Segment Spacing",
             min = 0,
             max = 12,
             step = 1,
+            order = 3,
+            get = function() return db.powerSpacing or 2 end,
+            set = function(_, value)
+              db.powerSpacing = value
+              addon:FullUpdate()
+            end,
+          },
+          heightCast = {
+            type = "range",
+            name = "Cast Bar Height",
+            min = 8,
+            max = 40,
+            step = 1,
+            order = 4,
+            get = function() return db.height.cast end,
+            set = function(_, value)
+              db.height.cast = value
+              addon:FullUpdate()
+            end,
+          },
+          heightHP = {
+            type = "range",
+            name = "Health Bar Height",
+            min = 8,
+            max = 40,
+            step = 1,
             order = 5,
-            get = function() return db.profile.spacing or 2 end,
+            get = function() return db.height.hp end,
             set = function(_, value)
-              db.profile.spacing = value
+              db.height.hp = value
               addon:FullUpdate()
-              addon:BuildFramesForSpec()
             end,
           },
-          texture = {
-            type = "select",
-            name = "Bar Texture",
-            dialogControl = "LSM30_Statusbar",
+          heightResource = {
+            type = "range",
+            name = "Primary Resource Height",
+            min = 8,
+            max = 40,
+            step = 1,
             order = 6,
-            values = LSM and LSM:HashTable("statusbar") or {},
-            get = function() return db.profile.textures.bar end,
+            get = function() return db.height.resource end,
             set = function(_, value)
-              db.profile.textures.bar = value
-              addon:ApplyBarSkins()
+              db.height.resource = value
+              addon:FullUpdate()
             end,
           },
-          font = {
-            type = "select",
-            name = "Font",
-            dialogControl = "LSM30_Font",
+          heightPower = {
+            type = "range",
+            name = "Special Power Height",
+            min = 8,
+            max = 40,
+            step = 1,
             order = 7,
-            values = LSM and LSM:HashTable("font") or {},
-            get = function() return db.profile.textures.font end,
+            get = function() return db.height.power end,
             set = function(_, value)
-              db.profile.textures.font = value
+              db.height.power = value
               addon:FullUpdate()
-              addon:BuildFramesForSpec()
             end,
           },
         },
@@ -711,389 +495,116 @@ function ClassHUD_BuildOptions(addon)
       bars = {
         type = "group",
         name = "Bars",
-        order = 2,
-        inline = false,
+        inline = true,
+        order = 4,
         args = {
-          showCast = {
+          cast = {
             type = "toggle",
             name = "Show Cast Bar",
             order = 1,
-            get = function() return db.profile.show.cast end,
+            get = function() return db.show.cast end,
             set = function(_, value)
-              db.profile.show.cast = value
+              db.show.cast = value
               addon:FullUpdate()
             end,
           },
-          showHP = {
+          hp = {
             type = "toggle",
             name = "Show Health Bar",
             order = 2,
-            get = function() return db.profile.show.hp end,
+            get = function() return db.show.hp end,
             set = function(_, value)
-              db.profile.show.hp = value
+              db.show.hp = value
               addon:FullUpdate()
             end,
           },
-          showResource = {
+          resource = {
             type = "toggle",
             name = "Show Primary Resource",
             order = 3,
-            get = function() return db.profile.show.resource end,
+            get = function() return db.show.resource end,
             set = function(_, value)
-              db.profile.show.resource = value
+              db.show.resource = value
               addon:FullUpdate()
             end,
           },
-          showPower = {
+          power = {
             type = "toggle",
-            name = "Show Special Power",
+            name = "Show Class Power",
             order = 4,
-            get = function() return db.profile.show.power end,
+            get = function() return db.show.power end,
             set = function(_, value)
-              db.profile.show.power = value
+              db.show.power = value
               addon:FullUpdate()
             end,
           },
-          showBuffs = {
-            type = "toggle",
-            name = "Show Tracked Buff Bar",
-            order = 5,
-            get = function() return db.profile.show.buffs end,
+        },
+      },
+      textures = {
+        type = "group",
+        name = "Textures & Fonts",
+        inline = true,
+        order = 5,
+        args = {
+          bar = {
+            type = "select",
+            name = "Bar Texture",
+            dialogControl = LSM and "LSM30_Statusbar" or nil,
+            order = 1,
+            values = function()
+              return (LSM and LSM:HashTable("statusbar")) or {}
+            end,
+            get = function() return db.textures.bar end,
             set = function(_, value)
-              db.profile.show.buffs = value
-              addon:BuildTrackedBuffFrames()
+              db.textures.bar = value
+              addon:ApplyBarSkins()
             end,
           },
-          borderColor = {
-            type = "color",
-            name = "Bar Border Color",
-            order = 10,
-            hasAlpha = true,
-            get = function()
-              return db.profile.borderColor.r, db.profile.borderColor.g, db.profile.borderColor.b,
-                  db.profile.borderColor.a
+          font = {
+            type = "select",
+            name = "Font",
+            dialogControl = LSM and "LSM30_Font" or nil,
+            order = 2,
+            values = function()
+              return (LSM and LSM:HashTable("font")) or {}
             end,
-            set = function(_, r, g, b, a)
-              db.profile.borderColor = { r = r, g = g, b = b, a = a }
-              addon:ApplyBarSkins()
+            get = function() return db.textures.font end,
+            set = function(_, value)
+              db.textures.font = value
+              addon:FullUpdate()
             end,
           },
           spellFontSize = {
             type = "range",
-            name = "Spell Text Size",
+            name = "Cast Bar Font Size",
             min = 8,
             max = 24,
             step = 1,
-            order = 8,
-            get = function() return db.profile.spellFontSize or 12 end,
-            set = function(_, v)
-              db.profile.spellFontSize = v
-              addon:BuildFramesForSpec()
-            end,
-          },
-          buffFontSize = {
-            type = "range",
-            name = "Buff Text Size",
-            min = 8,
-            max = 24,
-            step = 1,
-            order = 9,
-            get = function() return db.profile.buffFontSize or 12 end,
-            set = function(_, v)
-              db.profile.buffFontSize = v
-              addon:BuildFramesForSpec()
-            end,
-          },
-          trackedBarHeight = {
-            type = "range",
-            name = "Tracked Bar Height",
-            order = 6,
-            min = 8,
-            max = 40,
-            step = 1,
-            get = function() return db.profile.trackedBuffBar.height or 16 end,
+            order = 3,
+            get = function() return db.spellFontSize or 12 end,
             set = function(_, value)
-              db.profile.trackedBuffBar.height = value
-              addon:BuildTrackedBuffFrames()
-            end,
-          },
-          spacing = {
-            type = "range",
-            name = "Vertical Spacing",
-            min = 0,
-            max = 30,
-            step = 1,
-            order = 5,
-            get = function() return db.profile.spacing or 2 end,
-            set = function(_, value)
-              db.profile.spacing = value
-              addon:FullUpdate()
-              addon:BuildFramesForSpec()
-            end,
-          },
-
-          powerSpacing = {
-            type = "range",
-            name = "Power Spacing",
-            order = 7,
-            min = 0,
-            max = 12,
-            step = 1,
-            get = function() return db.profile.powerSpacing or 2 end,
-            set = function(_, value)
-              db.profile.powerSpacing = value
+              db.spellFontSize = value
               addon:FullUpdate()
             end,
-          },
-          heightCast = {
-            type = "range",
-            name = "Cast Height",
-            order = 8,
-            min = 8,
-            max = 40,
-            step = 1,
-            get = function() return db.profile.height.cast end,
-            set = function(_, value)
-              db.profile.height.cast = value
-              addon:FullUpdate()
-            end,
-          },
-          heightHP = {
-            type = "range",
-            name = "Health Height",
-            order = 9,
-            min = 8,
-            max = 40,
-            step = 1,
-            get = function() return db.profile.height.hp end,
-            set = function(_, value)
-              db.profile.height.hp = value
-              addon:FullUpdate()
-            end,
-          },
-          heightResource = {
-            type = "range",
-            name = "Resource Height",
-            order = 10,
-            min = 8,
-            max = 40,
-            step = 1,
-            get = function() return db.profile.height.resource end,
-            set = function(_, value)
-              db.profile.height.resource = value
-              addon:FullUpdate()
-            end,
-          },
-          heightPower = {
-            type = "range",
-            name = "Special Power Height",
-            order = 11,
-            min = 8,
-            max = 40,
-            step = 1,
-            get = function() return db.profile.height.power end,
-            set = function(_, value)
-              db.profile.height.power = value
-              addon:FullUpdate()
-            end,
-          },
-          topLayout = {
-            type = "group",
-            name = "Top Bar Layout",
-            order = 20,
-            inline = true,
-            args = {
-              perRow = {
-                type = "range",
-                name = "Spells per Row",
-                order = 1,
-                min = 1,
-                max = 12,
-                step = 1,
-                get = function() return db.profile.topBar.perRow end,
-                set = function(_, value)
-                  db.profile.topBar.perRow = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              spacingX = {
-                type = "range",
-                name = "Horizontal Spacing",
-                order = 2,
-                min = 0,
-                max = 20,
-                step = 1,
-                get = function() return db.profile.topBar.spacingX end,
-                set = function(_, value)
-                  db.profile.topBar.spacingX = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              spacingY = {
-                type = "range",
-                name = "Vertical Spacing",
-                order = 3,
-                min = 0,
-                max = 20,
-                step = 1,
-                get = function() return db.profile.topBar.spacingY end,
-                set = function(_, value)
-                  db.profile.topBar.spacingY = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              yOffset = {
-                type = "range",
-                name = "Vertical Offset",
-                order = 4,
-                min = -100,
-                max = 100,
-                step = 1,
-                get = function() return db.profile.topBar.yOffset end,
-                set = function(_, value)
-                  db.profile.topBar.yOffset = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-            },
-          },
-          bottomLayout = {
-            type = "group",
-            name = "Bottom Bar Layout",
-            order = 21,
-            inline = true,
-            args = {
-              perRow = {
-                type = "range",
-                name = "Spells per Row",
-                order = 1,
-                min = 1,
-                max = 12,
-                step = 1,
-                get = function() return db.profile.bottomBar.perRow end,
-                set = function(_, value)
-                  db.profile.bottomBar.perRow = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              spacingX = {
-                type = "range",
-                name = "Horizontal Spacing",
-                order = 2,
-                min = 0,
-                max = 20,
-                step = 1,
-                get = function() return db.profile.bottomBar.spacingX end,
-                set = function(_, value)
-                  db.profile.bottomBar.spacingX = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              spacingY = {
-                type = "range",
-                name = "Vertical Spacing",
-                order = 3,
-                min = 0,
-                max = 20,
-                step = 1,
-                get = function() return db.profile.bottomBar.spacingY end,
-                set = function(_, value)
-                  db.profile.bottomBar.spacingY = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              yOffset = {
-                type = "range",
-                name = "Vertical Offset",
-                order = 4,
-                min = -100,
-                max = 100,
-                step = 1,
-                get = function() return db.profile.bottomBar.yOffset end,
-                set = function(_, value)
-                  db.profile.bottomBar.yOffset = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-            },
-          },
-          sideLayout = {
-            type = "group",
-            name = "Side Bars",
-            order = 22,
-            inline = true,
-            args = {
-              size = {
-                type = "range",
-                name = "Icon Size",
-                order = 1,
-                min = 24,
-                max = 80,
-                step = 1,
-                get = function() return db.profile.sideBars.size end,
-                set = function(_, value)
-                  db.profile.sideBars.size = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              spacing = {
-                type = "range",
-                name = "Spacing",
-                order = 2,
-                min = 0,
-                max = 20,
-                step = 1,
-                get = function() return db.profile.sideBars.spacing end,
-                set = function(_, value)
-                  db.profile.sideBars.spacing = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              offset = {
-                type = "range",
-                name = "Offset",
-                order = 3,
-                min = -200,
-                max = 200,
-                step = 1,
-                get = function() return db.profile.sideBars.offset end,
-                set = function(_, value)
-                  db.profile.sideBars.offset = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-              yOffset = {
-                type = "range",
-                name = "Sidebar Y-Offset",
-                order = 4,
-                min = -200,
-                max = 200,
-                step = 1,
-                get = function() return db.profile.sideBars.yOffset or 0 end,
-                set = function(_, value)
-                  db.profile.sideBars.yOffset = value
-                  addon:BuildFramesForSpec()
-                end,
-              },
-            },
           },
         },
       },
       colors = {
         type = "group",
         name = "Colors",
-        order = 3,
+        inline = true,
+        order = 6,
         args = {
           hp = {
             type = "color",
             name = "Health",
             order = 1,
             get = function()
-              local c = db.profile.colors.hp
+              local c = db.colors.hp
               return c.r, c.g, c.b
             end,
             set = function(_, r, g, b)
-              db.profile.colors.hp = { r = r, g = g, b = b }
+              db.colors.hp = { r = r, g = g, b = b }
               addon:UpdateHP()
             end,
           },
@@ -1101,9 +612,9 @@ function ClassHUD_BuildOptions(addon)
             type = "toggle",
             name = "Use Class Color for Primary Resource",
             order = 2,
-            get = function() return db.profile.colors.resourceClass end,
+            get = function() return db.colors.resourceClass end,
             set = function(_, value)
-              db.profile.colors.resourceClass = value
+              db.colors.resourceClass = value
               addon:UpdatePrimaryResource()
             end,
           },
@@ -1111,302 +622,50 @@ function ClassHUD_BuildOptions(addon)
             type = "color",
             name = "Primary Resource",
             order = 3,
+            disabled = function() return db.colors.resourceClass end,
             get = function()
-              local c = db.profile.colors.resource
+              local c = db.colors.resource
               return c.r, c.g, c.b
             end,
             set = function(_, r, g, b)
-              db.profile.colors.resource = { r = r, g = g, b = b }
+              db.colors.resource = { r = r, g = g, b = b }
               addon:UpdatePrimaryResource()
             end,
-            disabled = function() return db.profile.colors.resourceClass end,
           },
           power = {
             type = "color",
-            name = "Special Power",
+            name = "Class Power",
             order = 4,
             get = function()
-              local c = db.profile.colors.power
+              local c = db.colors.power
               return c.r, c.g, c.b
             end,
             set = function(_, r, g, b)
-              db.profile.colors.power = { r = r, g = g, b = b }
+              db.colors.power = { r = r, g = g, b = b }
               addon:UpdateSpecialPower()
             end,
           },
         },
       },
-      spells = {
-        type = "group",
-        name = "Spells & Buffs",
-        order = 4,
-        args = {
-          -- topBar = {
-          --   type = "group",
-          --   name = "Top Bar Spells",
-          --   order = 1,
-          --   args = {
-          --     description = {
-          --       type = "description",
-          --       name = "Assign essential abilities to HUD positions.",
-          --       order = 1,
-          --     },
-          --     addSpell = {
-          --       type = "input",
-          --       name = "Add Spell ID",
-          --       order = 2,
-          --       width = "half",
-          --       get = function() return "" end,
-          --       set = function(_, value)
-          --         local spellID = tonumber(value)
-          --         if not spellID then return end
-          --         local class, specID = addon:GetPlayerClassSpec()
-          --         addon.db.profile.utilityPlacement[class] = addon.db.profile.utilityPlacement[class] or {}
-          --         addon.db.profile.utilityPlacement[class][specID] = addon.db.profile.utilityPlacement[class][specID] or
-          --             {}
-          --         addon.db.profile.utilityPlacement[class][specID][spellID] = "TOP"
+    },
+  }
+end
 
-          --         addon:BuildFramesForSpec()
-          --         BuildPlacementArgs(addon, topBarContainer, "essential", "TOP",
-          --           "No essential spells reported for this spec.")
-          --         NotifyOptionsChanged()
-          --       end,
-          --     },
-          --     list = {
-          --       type = "group",
-          --       name = "Assignments",
-          --       inline = true,
-          --       order = 3,
-          --       args = topBarContainer,
-          --     },
-          --   },
-          -- },
-          topBar = {
-            type  = "group",
-            name  = "Top Bar Spells",
-            order = 1,
-            args  = {
-              description = {
-                type  = "description",
-                name  = "Manage spells that appear on the Top Bar and link buffs directly to them.",
-                order = 1,
-              },
-              addSpell = {
-                type  = "input",
-                name  = "Add Spell ID",
-                order = 2,
-                width = "half",
-                get   = function() return "" end,
-                set   = function(_, value)
-                  local spellID = tonumber(value)
-                  if not spellID then return end
-                  local class, specID = addon:GetPlayerClassSpec()
-                  addon.db.profile.utilityPlacement[class] = addon.db.profile.utilityPlacement[class] or {}
-                  addon.db.profile.utilityPlacement[class][specID] = addon.db.profile.utilityPlacement[class][specID] or
-                      {}
-                  addon.db.profile.utilityPlacement[class][specID][spellID] = "TOP"
-                  BuildTopBarSpellsEditor(addon, topBarEditorContainer)
-                  addon:BuildFramesForSpec()
-                  local ACR = LibStub("AceConfigRegistry-3.0", true)
-                  if ACR then ACR:NotifyChange("ClassHUD") end
-                end,
-              },
-              editor = {
-                type   = "group",
-                name   = "",   -- tomt navn = ingen label
-                order  = 3,
-                inline = true, -- VIKTIG: ingen ny venstremeny-node
-                args   = topBarEditorContainer,
-              },
-            },
-          },
-
-
-          utility = {
-            type = "group",
-            name = "Utility Placement",
-            order = 2,
-            args = {
-              addSpell = {
-                type = "input",
-                name = "Add Spell ID",
-                order = 1,
-                width = "half",
-                get = function() return "" end,
-                set = function(_, value)
-                  local spellID = tonumber(value)
-                  if not spellID then return end
-                  local class, specID = addon:GetPlayerClassSpec()
-                  addon.db.profile.utilityPlacement[class] = addon.db.profile.utilityPlacement[class] or {}
-                  addon.db.profile.utilityPlacement[class][specID] = addon.db.profile.utilityPlacement[class][specID] or
-                      {}
-                  addon.db.profile.utilityPlacement[class][specID][spellID] = "HIDDEN"
-                  addon:BuildFramesForSpec()
-                  BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN",
-                    "No utility cooldowns reported by the snapshot for this spec.")
-                  NotifyOptionsChanged()
-                end,
-              },
-              list = {
-                type = "group",
-                name = "Spells",
-                inline = true,
-                order = 2,
-                args = utilityContainer,
-              },
-            },
-          },
-          trackedBuffs = {
-            type = "group",
-            name = "Tracked Buffs & Bars",
-            order = 3,
-            args = {
-              description = {
-                type = "description",
-                name = "Configure which Blizzard tracked buffs and cooldown bars appear in the HUD.",
-                order = 1,
-              },
-              addBuff = {
-                type = "input",
-                name = "Add Buff ID",
-                order = 2,
-                width = "half",
-                get = function() return "" end,
-                set = function(_, value)
-                  local buffID = tonumber(value)
-                  if not buffID then return end
-                  local class, specID = addon:GetPlayerClassSpec()
-                  addon.db.profile.trackedBuffs[class] = addon.db.profile.trackedBuffs[class] or {}
-                  addon.db.profile.trackedBuffs[class][specID] = addon.db.profile.trackedBuffs[class][specID] or {}
-                  addon.db.profile.trackedBuffs[class][specID][buffID] = true
-                  addon:BuildTrackedBuffFrames()
-                  BuildTrackedBuffArgs(addon, trackedContainer)
-                  NotifyOptionsChanged()
-                end,
-              },
-              list = {
-                type = "group",
-                name = "Entries",
-                inline = true,
-                order = 3,
-                args = trackedContainer,
-              },
-            },
-          },
-          -- buffLinks = {
-          --   type = "group",
-          --   name = "Buff Links",
-          --   order = 4,
-          --   args = {
-          --     description = {
-          --       type = "description",
-          --       name = "Manual overrides linking a buff to a spell. These are populated automatically when possible.",
-          --       order = 1,
-          --     },
-          --     list = {
-          --       type = "group",
-          --       name = "Links",
-          --       inline = true,
-          --       order = 2,
-          --       args = linkContainer,
-          --     },
-          --     add = {
-          --       type = "group",
-          --       name = "Add New Link",
-          --       inline = true,
-          --       order = 3,
-          --       args = {
-          --         buffID = {
-          --           type = "input",
-          --           name = "Buff ID",
-          --           order = 1,
-          --           width = "half",
-          --           get = function() return optionsState.newLinkBuffID end,
-          --           set = function(_, value)
-          --             optionsState.newLinkBuffID = value or ""
-          --           end,
-          --         },
-          --         spellID = {
-          --           type = "input",
-          --           name = "Spell ID",
-          --           order = 2,
-          --           width = "half",
-          --           get = function() return optionsState.newLinkSpellID end,
-          --           set = function(_, value)
-          --             optionsState.newLinkSpellID = value or ""
-          --           end,
-          --         },
-          --         addButton = {
-          --           type = "execute",
-          --           name = "Add Link",
-          --           order = 3,
-          --           func = function()
-          --             local buffID = tonumber(optionsState.newLinkBuffID)
-          --             local spellID = tonumber(optionsState.newLinkSpellID)
-          --             if not (buffID and spellID) then return end
-          --             local class, specID = addon:GetPlayerClassSpec()
-          --             addon.db.profile.buffLinks[class] = addon.db.profile.buffLinks[class] or {}
-          --             addon.db.profile.buffLinks[class][specID] = addon.db.profile.buffLinks[class][specID] or {}
-          --             addon.db.profile.buffLinks[class][specID][buffID] = spellID
-          --             addon:BuildFramesForSpec()
-          --             BuildBuffLinkArgs(addon, linkContainer)
-          --             optionsState.newLinkBuffID = ""
-          --             optionsState.newLinkSpellID = ""
-          --             NotifyOptionsChanged()
-          --           end,
-          --         },
-          --       },
-          --     },
-          --   },
-          -- },
-        },
-      },
-      snapshot = {
-        type = "group",
-        name = "Snapshot",
-        order = 5,
-        args = {
-          refresh = {
-            type = "execute",
-            name = "Refresh Snapshot",
-            order = 1,
-            func = function()
-              addon:UpdateCDMSnapshot()
-              addon:BuildFramesForSpec()
-              BuildTopBarSpellsEditor(addon, topBarEditorContainer)
-              BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN",
-                "No utility cooldowns reported by the snapshot for this spec.")
-              BuildTrackedBuffArgs(addon, trackedContainer)
-              BuildBuffLinkArgs(addon, linkContainer)
-              NotifyOptionsChanged()
-            end,
-          },
-          note = {
-            type = "description",
-            order = 2,
-            name =
-            "The snapshot is rebuilt automatically on login and specialization changes. Use this button if Blizzard updates the Cooldown Viewer data while you are logged in.",
-          },
-        },
-      },
+function ClassHUD_BuildOptions(addon)
+  local options = {
+    type = "group",
+    name = "ClassHUD",
+    childGroups = "tab",
+    args = {
+      general = BuildGeneralGroup(addon),
+      tracked = BuildTrackedGroup(addon),
     },
   }
 
-  BuildTopBarSpellsEditor(addon, topBarEditorContainer)
-  BuildPlacementArgs(addon, utilityContainer, "utility", "HIDDEN",
-    "No utility cooldowns reported by the snapshot for this spec.")
-  BuildTrackedBuffArgs(addon, trackedContainer)
-  BuildBuffLinkArgs(addon, linkContainer)
+  if AceDBOptions and addon.db then
+    options.args.profiles = AceDBOptions:GetOptionsTable(addon.db)
+    options.args.profiles.order = 99
+  end
 
-  return opts
-end
-
-function ClassHUD:GetUtilityOptions()
-  local container = {}
-  BuildPlacementArgs(self, container, "utility", "HIDDEN", "No utility cooldowns reported by the snapshot for this spec.")
-  return {
-    type = "group",
-    name = "Utility Cooldowns",
-    args = container,
-  }
+  return options
 end

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -1,713 +1,108 @@
--- ClassHUD_Spells.lua (CDM-liste -> egen visningslogikk)
----@type ClassHUD
 local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
 local UI = ClassHUD.UI
 
-ClassHUD.spellFrames = ClassHUD.spellFrames or {}
-ClassHUD.trackedBuffFrames = ClassHUD.trackedBuffFrames or {}
-ClassHUD.trackedBarFrames = ClassHUD.trackedBarFrames or {}
-ClassHUD._trackedBuffFramePool = ClassHUD._trackedBuffFramePool or {}
-ClassHUD._trackedBarFramePool = ClassHUD._trackedBarFramePool or {}
-
-local activeFrames = {}
-local trackedBuffPool = ClassHUD._trackedBuffFramePool
-local trackedBarPool = ClassHUD._trackedBarFramePool
-
-local INACTIVE_BAR_COLOR = { r = 0.25, g = 0.25, b = 0.25, a = 0.6 }
 local TRACKED_UNITS = { "player", "pet" }
 
-local function EnsureAttachment(name)
-  if not UI.anchor then return nil end
-  UI.attachments = UI.attachments or {}
-  if not UI.attachments[name] then
-    UI.attachments[name] = CreateFrame("Frame", "ClassHUDAttach" .. name, UI.anchor)
-    UI.attachments[name]._height = 0
+ClassHUD.trackedBuffFrames = ClassHUD.trackedBuffFrames or {}
+ClassHUD._trackedBuffFramePool = ClassHUD._trackedBuffFramePool or {}
+
+local activeFrames = ClassHUD.trackedBuffFrames
+local framePool = ClassHUD._trackedBuffFramePool
+
+local function EnsureBuffContainer()
+  if not UI.buffContainer then
+    UI.buffContainer = CreateFrame("Frame", "ClassHUDTrackedBuffContainer", UI.anchor)
+    UI.buffContainer:SetSize(1, 1)
   end
-  return UI.attachments[name]
+  UI.buffContainer:SetParent(UI.anchor)
+  return UI.buffContainer
 end
 
--- Overlay-glow helper: dedup + fallback til SpellAlertManager hvis Show/HideOverlayGlow ikke finnes
-local function SetOverlayGlow(frame, enable)
-  if enable then
-    if not frame.isGlowing then
-      if ActionButton_ShowOverlayGlow then
-        ActionButton_ShowOverlayGlow(frame)
-      else
-        ActionButtonSpellAlertManager:ShowAlert(frame)
-      end
-      frame.isGlowing = true
-    end
-  else
-    if frame.isGlowing then
-      if ActionButton_HideOverlayGlow then
-        ActionButton_HideOverlayGlow(frame)
-      else
-        ActionButtonSpellAlertManager:HideAlert(frame)
-      end
-      frame.isGlowing = false
-    end
-  end
-end
+local function AcquireBuffFrame(buffID)
+  local frame = framePool[buffID]
+  if not frame then
+    local container = EnsureBuffContainer()
+    frame = CreateFrame("Frame", nil, container)
+    frame:SetSize(32, 32)
 
+    frame.icon = frame:CreateTexture(nil, "ARTWORK")
+    frame.icon:SetAllPoints(true)
+    frame.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
 
-local function CopyColor(tbl)
-  if type(tbl) ~= "table" then return nil end
-  return {
-    r = tbl.r or 1,
-    g = tbl.g or 1,
-    b = tbl.b or 1,
-    a = tbl.a or 1,
-  }
-end
+    frame.cooldown = CreateFrame("Cooldown", nil, frame, "CooldownFrameTemplate")
+    frame.cooldown:SetAllPoints(true)
+    frame.cooldown:SetHideCountdownNumbers(true)
 
-local function CollectAuraSpellIDs(entry, primaryID)
-  return ClassHUD:GetAuraCandidatesForEntry(entry, primaryID)
-end
-
-local function FindAuraFromCandidates(candidates)
-  return ClassHUD:FindAuraFromCandidates(candidates, TRACKED_UNITS)
-end
-
--- ==================================================
--- Helpers
--- ==================================================
-
----Refreshes the in-memory snapshot cache used by spell frames.
-function ClassHUD:RefreshSnapshotCache()
-  self.cdmSpells = {}
-
-  local snapshot = self:GetSnapshotForSpec(nil, nil, false)
-  if not snapshot then return end
-
-  for spellID, entry in pairs(snapshot) do
-    if entry.categories then
-      self.cdmSpells[spellID] = entry.categories
-    end
-  end
-end
-
--- =====================
--- Helpers
--- =====================
-
-local function UpdateSpellIcon(frame, sid, entry)
-  local iconID = entry and entry.iconID
-  if not iconID then
-    local s = C_Spell.GetSpellInfo(sid)
-    iconID = s and s.iconID
-  end
-  frame.icon:SetTexture(iconID or 134400)
-end
-
-local function UpdateCooldown(frame, sid, gcdActive)
-  local cdStart, cdDuration
-  local shouldDesaturate = false
-
-  -- Charges
-  local ch = C_Spell.GetSpellCharges(sid)
-  local chargesShown = false
-  if ch and ch.maxCharges and ch.maxCharges > 1 then
-    local current = ch.currentCharges or 0
-    frame.count:SetText(current)
-    frame.count:Show()
-    chargesShown = true
-
-    if current < ch.maxCharges and ch.cooldownStartTime and ch.cooldownDuration and ch.cooldownDuration > 0 then
-      cdStart = ch.cooldownStartTime
-      cdDuration = ch.cooldownDuration
-    end
-
-    shouldDesaturate = (current <= 0)
-  else
+    frame.count = frame:CreateFontString(nil, "OVERLAY")
+    frame.count:SetPoint("BOTTOMRIGHT", -2, 2)
+    frame.count:SetText("")
     frame.count:Hide()
-    local cd = C_Spell.GetSpellCooldown(sid)
-    if cd and cd.startTime and cd.duration and cd.duration > 1.5 then
-      cdStart = cd.startTime
-      cdDuration = cd.duration
-      shouldDesaturate = true
-    end
+
+    frame.buffID = buffID
+    framePool[buffID] = frame
   end
 
-  -- GCD overlay (spellID 61304)
-  local gcd = C_Spell.GetSpellCooldown(61304)
-  if gcd and gcd.startTime and gcd.duration and gcd.duration > 0 then
-    if not cdStart or (gcd.startTime + gcd.duration) > (cdStart + cdDuration) then
-      cdStart    = gcd.startTime
-      cdDuration = gcd.duration
-      gcdActive  = true
-      -- Viktig: ikke sett frame._cooldownEnd for GCD, da vil teksten dukke opp
-    end
-  end
-
-  if cdStart and cdDuration then
-    CooldownFrame_Set(frame.cooldown, cdStart, cdDuration, true)
-
-    if not gcdActive then
-      frame._cooldownEnd = cdStart + cdDuration
-    else
-      frame._cooldownEnd = nil
-    end
-  else
-    CooldownFrame_Clear(frame.cooldown)
-    frame._cooldownEnd = nil
-  end
-
-
-  frame.icon:SetDesaturated(shouldDesaturate)
-  return chargesShown, gcdActive
-end
-
-local function UpdateAuraOverlay(frame, aura, chargesShown)
-  if aura then
-    local stacks = aura.applications or aura.stackCount or aura.charges or 0
-    if aura.duration and aura.duration > 0 and aura.expirationTime then
-      frame.cooldown:SetSwipeColor(1, 0.85, 0.1, 0.9)
-      CooldownFrame_Set(frame.cooldown, aura.expirationTime - aura.duration, aura.duration, true)
-      frame._cooldownEnd = aura.expirationTime
-      frame.icon:SetVertexColor(1, 1, 0.3)
-    else
-      frame.cooldown:SetSwipeColor(0, 0, 0, 0.25)
-      frame.icon:SetVertexColor(1, 1, 1)
-    end
-
-    if stacks > 1 and not chargesShown then
-      frame.count:SetText(stacks)
-      frame.count:Show()
-    end
-  else
-    frame.cooldown:SetSwipeColor(0, 0, 0, 0.25)
-    frame.icon:SetVertexColor(1, 1, 1)
-  end
-end
-
--- Erstatt hele UpdateGlow med denne:
-local function UpdateGlow(frame, aura, sid, data)
-  -- 1) Samme semantikk som original: aura tilstede → glow
-  local shouldGlow = (aura ~= nil)
-
-  -- 2) Manuelle buffLinks kan holde glow (som originalt "keepGlow")
-  if not shouldGlow then
-    local class, specID = ClassHUD:GetPlayerClassSpec()
-    local links = (ClassHUD.db.profile.buffLinks[class] and ClassHUD.db.profile.buffLinks[class][specID]) or {}
-    -- links: [buffID] = linkedSpellID
-    for buffID, linkedSpellID in pairs(links) do
-      if linkedSpellID == sid and ClassHUD:GetAuraForSpell(buffID) then
-        shouldGlow = true
-        break
-      end
-    end
-  end
-
-  -- 3) Auto-mapping fallback (som i originalens "keepGlow")
-  if not shouldGlow and ClassHUD.trackedBuffToSpell then
-    for buffID, mappedSpellID in pairs(ClassHUD.trackedBuffToSpell) do
-      if mappedSpellID == sid and ClassHUD:GetAuraForSpell(buffID) then
-        shouldGlow = true
-        break
-      end
-    end
-  end
-
-  -- 4) Idempotent toggle (ikke spam Show/Hide)
-  if shouldGlow and not frame.isGlowing then
-    ActionButtonSpellAlertManager:ShowAlert(frame)
-    frame.isGlowing = true
-  elseif not shouldGlow and frame.isGlowing then
-    ActionButtonSpellAlertManager:HideAlert(frame)
-    frame.isGlowing = false
-  end
-end
-
-
-local function UpdateCooldownText(frame, gcdActive)
-  -- Kortslutt: aldri tekst for GCD
-  if gcdActive then
-    frame.cooldownText:SetText("")
-    frame.cooldownText:Hide()
-    return
-  end
-
-  if frame._cooldownEnd then
-    local remain = frame._cooldownEnd - GetTime()
-    if remain <= 0 then
-      frame.cooldownText:SetText("")
-      frame.cooldownText:Hide()
-    else
-      local secs = math.floor(remain + 0.5)
-      if secs > 0 then
-        frame.cooldownText:SetText(secs)
-        frame.cooldownText:Show()
-      else
-        frame.cooldownText:SetText("")
-        frame.cooldownText:Hide()
-      end
-    end
-  else
-    frame.cooldownText:SetText("")
-    frame.cooldownText:Hide()
-  end
-end
-
-
-
--- ==================================================
--- Frame factory
--- ==================================================
-local function CreateSpellFrame(spellID)
-  if ClassHUD.spellFrames[spellID] then
-    return ClassHUD.spellFrames[spellID]
-  end
-
-  local frame = CreateFrame("Frame", "ClassHUDSpell" .. spellID, UI.anchor)
-  frame:SetSize(40, 40)
-
-  frame.icon = frame:CreateTexture(nil, "ARTWORK")
-  frame.icon:SetAllPoints(frame)
-
-  -- Cooldown
-  frame.cooldown = CreateFrame("Cooldown", nil, frame, "CooldownFrameTemplate")
-  frame.cooldown:SetAllPoints(frame)
-  frame.cooldown:SetHideCountdownNumbers(true)
-  frame.cooldown.noCooldownCount = true
-
-  -- Overlay-frame (alltid over cooldown)
-  frame.overlay = CreateFrame("Frame", nil, frame)
-  frame.overlay:SetAllPoints(frame)
-  frame.overlay:SetFrameLevel(frame.cooldown:GetFrameLevel() + 1)
-
-  -- Flytt tekstene til overlay
-  frame.count = frame.overlay:CreateFontString(nil, "OVERLAY")
-  frame.count:ClearAllPoints()
-  frame.count:SetPoint("TOP", frame, "TOP", 0, -2)
-  local fontPath, fontSize = ClassHUD:FetchFont(ClassHUD.db.profile.spellFontSize or 12)
-  frame.count:SetFont(fontPath, fontSize, "OUTLINE")
-  frame.count:Hide()
-
-  frame.cooldownText = frame.overlay:CreateFontString(nil, "OVERLAY")
-  frame.cooldownText:ClearAllPoints()
-  frame.cooldownText:SetPoint("BOTTOM", frame, "BOTTOM", 0, 2)
-  local fontPath, fontSize = ClassHUD:FetchFont(ClassHUD.db.profile.spellFontSize or 12)
-  frame.cooldownText:SetFont(fontPath, fontSize, "OUTLINE")
-  frame.cooldownText:Hide()
-
-
-  frame._cooldownEnd = nil
-  frame.spellID = spellID
-  frame.isGlowing = false
-
-  ClassHUD.spellFrames[spellID] = frame
-
-  frame:SetScript("OnUpdate", function(selfFrame)
-    if selfFrame._cooldownEnd then
-      local remain = selfFrame._cooldownEnd - GetTime()
-      if remain <= 0 then
-        selfFrame._cooldownEnd = nil
-        selfFrame.cooldownText:SetText("")
-        selfFrame.cooldownText:Hide()
-        selfFrame.icon:SetDesaturated(false)
-      else
-        if not selfFrame._gcdActive then -- 👈 aldri vis tekst på GCD
-          local secs = math.floor(remain + 0.5)
-          if secs > 0 then
-            selfFrame.cooldownText:SetText(secs)
-            selfFrame.cooldownText:Show()
-          else
-            selfFrame.cooldownText:SetText("")
-            selfFrame.cooldownText:Hide()
-          end
-        else
-          selfFrame.cooldownText:SetText("")
-          selfFrame.cooldownText:Hide()
-        end
-      end
-    end
-  end)
-
+  frame.count:SetFont(ClassHUD:FetchFont(ClassHUD.db.profile.buffFontSize or 12))
+  frame:SetSize(32, 32)
 
   return frame
 end
 
--- ==================================================
--- Layout helpers (bruker dine UI.attachments)
--- ==================================================
-
--- ==========================================================
--- Tracked Buffs Bar (over TopBar, dynamisk)
--- ==========================================================
-
-local function CreateBuffFrame(buffID)
-  if trackedBuffPool[buffID] then
-    return trackedBuffPool[buffID]
-  end
-
-  local parent = (UI.attachments and UI.attachments.TRACKED_ICONS) or UI.anchor
-  local f = CreateFrame("Frame", nil, parent)
-  f:SetSize(32, 32)
-
-  f.icon = f:CreateTexture(nil, "ARTWORK")
-  f.icon:SetAllPoints(true)
-  f.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
-
-  f.cooldown = CreateFrame("Cooldown", nil, f, "CooldownFrameTemplate")
-  f.cooldown:SetAllPoints(true)
-
-  f.count = f:CreateFontString(nil, "OVERLAY")
-  f.count:SetPoint("BOTTOMRIGHT", -2, 2)
-  f.count:SetFont(ClassHUD:FetchFont(12))
-  f.count:SetText("")
-  f.stacks = f.count
-
-  f.buffID = buffID
-  trackedBuffPool[buffID] = f
-
-  return f
+local function ResetFrame(frame)
+  frame.icon:SetVertexColor(1, 1, 1, 1)
+  frame.icon:SetDesaturated(false)
+  frame.count:SetText("")
+  frame.count:Hide()
+  CooldownFrame_Clear(frame.cooldown)
+  frame:Hide()
 end
 
-local function OnTrackedBarUpdate(self)
-  if not self._duration or not self._expiration then
-    self:SetScript("OnUpdate", nil)
-    return
+local function ExtractCooldown(info, spellID)
+  local start, duration, charges, iconID
+
+  if type(info) == "table" then
+    if info.startTimeMS then start = info.startTimeMS / 1000 end
+    if info.cooldownStartTimeMS then start = info.cooldownStartTimeMS / 1000 end
+    if info.startTime then start = info.startTime end
+    if info.cooldownStartTime then start = info.cooldownStartTime end
+
+    if info.durationMS then duration = info.durationMS / 1000 end
+    if info.cooldownDurationMS then duration = info.cooldownDurationMS / 1000 end
+    if info.duration then duration = info.duration end
+    if info.cooldownDuration then duration = info.cooldownDuration end
+
+    charges = info.applications or info.charges or info.currentCharges or info.maxCharges
+    iconID = info.iconTexture or info.iconID
   end
 
-  local remaining = self._expiration - GetTime()
-  if remaining < 0 then remaining = 0 end
-
-  self:SetValue(remaining)
-
-  if self._showTimer and self.timer then
-    self.timer:SetText(ClassHUD.FormatSeconds(remaining))
-    self.timer:Show()
-  elseif self.timer then
-    self.timer:Hide()
-  end
-
-  if remaining <= 0 then
-    self:SetScript("OnUpdate", nil)
-    ClassHUD:UpdateTrackedBarFrame(self)
-  end
-end
-
-local function CreateTrackedBarFrame(buffID)
-  if trackedBarPool[buffID] then
-    return trackedBarPool[buffID]
-  end
-
-  local parent = (UI.attachments and UI.attachments.TRACKED_BARS) or UI.anchor
-  local height = ClassHUD.db and ClassHUD.db.profile and ClassHUD.db.profile.trackedBuffBar
-      and ClassHUD.db.profile.trackedBuffBar.height or 16
-
-  local bar = ClassHUD:CreateStatusBar(parent, height)
-  bar.buffID = buffID
-  bar.auraSpellIDs = { buffID }
-  bar.text:Hide()
-  bar.icon = bar:CreateTexture(nil, "ARTWORK")
-  bar.icon:SetTexCoord(0.08, 0.92, 0.08, 0.92)
-  bar.icon:Hide()
-
-  bar.label = bar:CreateFontString(nil, "OVERLAY")
-  bar.label:SetFont(ClassHUD:FetchFont(12))
-  bar.label:SetJustifyH("LEFT")
-  bar.label:SetPoint("LEFT", bar, "LEFT", 4, 0)
-
-  bar.timer = bar:CreateFontString(nil, "OVERLAY")
-  bar.timer:SetFont(ClassHUD:FetchFont(12))
-  bar.timer:SetJustifyH("RIGHT")
-  bar.timer:SetPoint("TOPRIGHT", bar, "TOPRIGHT", -4, -2)
-  bar.timer:Hide()
-
-  bar.stacks = bar:CreateFontString(nil, "OVERLAY")
-  bar.stacks:SetFont(ClassHUD:FetchFont(12))
-  bar.stacks:SetPoint("BOTTOMRIGHT", bar, "BOTTOMRIGHT", -4, 2)
-  bar.stacks:SetJustifyH("RIGHT")
-  bar.stacks:Hide()
-
-  bar._duration = nil
-  bar._expiration = nil
-  bar._showTimer = true
-  bar._activeColor = CopyColor(ClassHUD:GetDefaultTrackedBarColor())
-  bar._inactiveColor = CopyColor(INACTIVE_BAR_COLOR)
-  bar.cooldownSpellID = buffID
-
-  bar:SetMinMaxValues(0, 1)
-  bar:SetValue(0)
-  bar:SetScript("OnUpdate", nil)
-
-  trackedBarPool[buffID] = bar
-  return bar
-end
-
-local function LayoutTrackedBars(barFrames, opts)
-  local container = EnsureAttachment("TRACKED_BARS")
-  if not container then return end
-
-  local settings   = ClassHUD.db.profile.trackedBuffBar or {}
-  local width      = ClassHUD.db.profile.width or 250
-  local spacingY   = settings.spacingY or 4
-  local barHeight  = settings.height or 16
-  local topPadding = 0
-
-  if #barFrames > 0 then
-    topPadding = (opts and opts.topPadding) or 0
-  end
-
-  container:SetWidth(width)
-
-  local currentY = topPadding
-  local totalHeight = (#barFrames > 0) and topPadding or 0
-
-  for index, frame in ipairs(barFrames) do
-    frame:SetParent(container)
-    frame:ClearAllPoints()
-    frame:SetHeight(barHeight)
-    frame:SetWidth(width)
-    frame:SetPoint("TOPLEFT", container, "TOPLEFT", 0, -currentY)
-    frame:SetPoint("TOPRIGHT", container, "TOPRIGHT", 0, -currentY)
-    frame:Show()
-
-    currentY = currentY + barHeight
-    totalHeight = currentY
-
-    if index < #barFrames then
-      currentY = currentY + spacingY
-      totalHeight = currentY
-    end
-  end
-
-  if #barFrames == 0 then
-    container._height = 0
-    container:SetHeight(0)
-    container._afterGap = nil
-  else
-    totalHeight = math.max(totalHeight, 0)
-    container._height = totalHeight
-    container:SetHeight(totalHeight)
-    container._afterGap = nil
-  end
-
-  container:Show()
-end
-
-local function LayoutTrackedIcons(iconFrames, opts)
-  local container = EnsureAttachment("TRACKED_ICONS")
-  if not container then return end
-
-  container:ClearAllPoints()
-  container:SetPoint("BOTTOM", UI.attachments.TOP, "TOP", 0, 4) -- 4 px over Top bar
-  container:SetWidth(ClassHUD.db.profile.width or 250)
-
-  local settings   = ClassHUD.db.profile.trackedBuffBar or {}
-  local width      = ClassHUD.db.profile.width or 250
-  local perRow     = math.max(settings.perRow or 8, 1)
-  local spacingX   = settings.spacingX or 4
-  local spacingY   = settings.spacingY or 4
-  local align      = settings.align or "CENTER"
-  local topPadding = 0
-
-  if #iconFrames > 0 then
-    topPadding = (opts and opts.topPadding) or 0
-  end
-
-  container:SetWidth(width)
-
-  local totalHeight = 0
-
-  if #iconFrames > 0 then
-    local size = (width - (perRow - 1) * spacingX) / perRow
-    if size < 1 then size = 1 end
-
-    local count = #iconFrames
-    local rowsUsed = math.ceil(count / perRow)
-
-    for index, frame in ipairs(iconFrames) do
-      frame:SetParent(container)
-      frame:SetSize(size, size)
-      frame:ClearAllPoints()
-
-      local row = math.floor((index - 1) / perRow)
-      local col = (index - 1) % perRow
-
-      local remaining = count - row * perRow
-      local rowCount = math.min(perRow, remaining)
-      local rowWidth = rowCount * size + math.max(0, rowCount - 1) * spacingX
-
-      local startX
-      if align == "LEFT" then
-        startX = 0
-      elseif align == "RIGHT" then
-        startX = width - rowWidth
-      else
-        startX = (width - rowWidth) / 2
+  if not start or not duration then
+    if C_Spell and C_Spell.GetSpellCooldown and spellID then
+      local cd = C_Spell.GetSpellCooldown(spellID)
+      if cd and cd.startTime and cd.duration and cd.duration > 0 then
+        start = cd.startTime
+        duration = cd.duration
       end
-
-      frame:SetPoint("TOPLEFT", container, "TOPLEFT",
-        startX + col * (size + spacingX),
-        -(topPadding + row * (size + spacingY)))
-      frame:Show()
-    end
-
-    local iconsHeight = rowsUsed * size + math.max(0, rowsUsed - 1) * spacingY
-    totalHeight = topPadding + iconsHeight
-  else
-    -- ingen aktive buffs → hold containeren i live med 1 px høyde
-    totalHeight = 1
-  end
-
-  container._height = totalHeight
-  container:SetHeight(totalHeight)
-  container._afterGap = nil
-  container:Show()
-end
-
-
-
-
-local function LayoutTopBar(frames)
-  local container = EnsureAttachment("TOP")
-  if not container then return end
-
-  local width    = ClassHUD.db.profile.width or 250
-  local perRow   = math.max(ClassHUD.db.profile.topBar.perRow or 8, 1)
-  local spacingX = ClassHUD.db.profile.topBar.spacingX or 4
-  local spacingY = ClassHUD.db.profile.topBar.spacingY or 4
-  local yOffset  = ClassHUD.db.profile.topBar.yOffset or 0
-  local grow     = ClassHUD.db.profile.topBar.grow or "DOWN"
-
-  container:SetWidth(width)
-
-  if #frames == 0 then
-    container._height = 0
-    container:SetHeight(0)
-    container._afterGap = nil
-    container:Show()
-    return
-  end
-
-  local size     = (width - (perRow - 1) * spacingX) / perRow
-  local count    = #frames
-  local rowsUsed = math.ceil(count / perRow)
-
-  for index, frame in ipairs(frames) do
-    frame:SetParent(container)
-    frame:SetSize(size, size)
-    frame:ClearAllPoints()
-
-    local row = math.floor((index - 1) / perRow)
-    local col = (index - 1) % perRow
-
-    local remaining = count - row * perRow
-    local rowCount = math.min(perRow, remaining)
-    local rowWidth = rowCount * size + math.max(0, rowCount - 1) * spacingX
-    local startX = (width - rowWidth) / 2
-
-    local x = startX + col * (size + spacingX)
-    local y = yOffset + row * (size + spacingY)
-
-    if grow == "UP" then
-      frame:SetPoint("BOTTOMLEFT", container, "BOTTOMLEFT", x, y)
-    else
-      frame:SetPoint("TOPLEFT", container, "TOPLEFT", x, -y)
-    end
-
-    frame:Show()
-  end
-
-  local totalHeight = yOffset + rowsUsed * size + math.max(0, rowsUsed - 1) * spacingY
-  totalHeight = math.max(totalHeight, 0)
-
-  container._height = totalHeight
-  container:SetHeight(totalHeight)
-  container._afterGap = ClassHUD.db.profile.spacing or 0 -- 👈 vertical spacing option
-  container:Show()
-end
-
-local function LayoutSideBar(frames, side)
-  if not UI.attachments or not UI.attachments[side] then return end
-  local size    = ClassHUD.db.profile.sideBars.size or 36
-  local spacing = ClassHUD.db.profile.sideBars.spacing or 4
-  local offset  = ClassHUD.db.profile.sideBars.offset or 6
-  local yOffset = ClassHUD.db.profile.sideBars.yOffset or 0
-  for i, frame in ipairs(frames) do
-    frame:SetSize(size, size)
-    frame:ClearAllPoints()
-    local y = yOffset - (i - 1) * (size + spacing)
-    if side == "LEFT" then
-      frame:SetPoint("TOPRIGHT", UI.attachments.LEFT, "TOPLEFT", -offset, y)
-    elseif side == "RIGHT" then
-      frame:SetPoint("TOPLEFT", UI.attachments.RIGHT, "TOPRIGHT", offset, y)
     end
   end
+
+  if not charges and C_Spell and C_Spell.GetSpellCharges and spellID then
+    local ch = C_Spell.GetSpellCharges(spellID)
+    if ch and ch.maxCharges and ch.maxCharges > 1 then
+      charges = ch.currentCharges or ch.maxCharges
+    end
+  end
+
+  return start, duration, charges, iconID
 end
 
-local function LayoutBottomBar(frames)
-  local container = EnsureAttachment("BOTTOM")
-  if not container then return end
-
-  local width    = ClassHUD.db.profile.width or 250
-  local perRow   = math.max(ClassHUD.db.profile.bottomBar.perRow or 8, 1)
-  local spacingX = ClassHUD.db.profile.bottomBar.spacingX or 4
-  local spacingY = ClassHUD.db.profile.bottomBar.spacingY or 4
-  local yOffset  = ClassHUD.db.profile.bottomBar.yOffset or 0
-
-  container:SetWidth(width)
-
-  if #frames == 0 then
-    container._height = 0
-    container:SetHeight(0)
-    container._afterGap = nil
-    container:Show()
-    return
+local function ApplyAuraVisuals(frame, aura, auraSpellID)
+  local icon = aura and (aura.icon or (auraSpellID and C_Spell.GetSpellTexture(auraSpellID)))
+  if icon then
+    frame.icon:SetTexture(icon)
   end
 
-  local size       = (width - (perRow - 1) * spacingX) / perRow
-  local count      = #frames
-  local rowsUsed   = math.ceil(count / perRow)
-  local topPadding = spacingY + yOffset
-
-  for index, frame in ipairs(frames) do
-    frame:SetSize(size, size)
-    frame:SetParent(container)
-    frame:ClearAllPoints()
-
-    local row       = math.floor((index - 1) / perRow)
-    local col       = (index - 1) % perRow
-    local remaining = count - row * perRow
-    local rowCount  = math.min(perRow, remaining)
-    local rowWidth  = rowCount * size + math.max(0, rowCount - 1) * spacingX
-    local startX    = (width - rowWidth) / 2
-
-    frame:SetPoint("TOPLEFT", container, "TOPLEFT",
-      startX + col * (size + spacingX),
-      -(topPadding + row * (size + spacingY)))
-    frame:Show()
-  end
-
-  local totalHeight = topPadding + rowsUsed * size + math.max(0, rowsUsed - 1) * spacingY
-  totalHeight = math.max(totalHeight, 0)
-  container._height = totalHeight
-  container:SetHeight(totalHeight)
-  container._afterGap = ClassHUD.db.profile.spacing or 0 -- 👈 vertical spacing option
-  container:Show()
-end
-
-local function PopulateBuffIconFrame(frame, buffID, aura, entry)
-  frame:SetParent(EnsureAttachment("TRACKED_ICONS") or UI.anchor)
-
-  local iconID = entry and entry.iconID
-  if not iconID then
-    local info = C_Spell.GetSpellInfo(buffID)
-    iconID = info and info.iconID
-  end
-
-  frame.icon:SetTexture(iconID or C_Spell.GetSpellTexture(buffID) or 134400)
-
-  if aura and aura.expirationTime and aura.duration and aura.duration > 0 then
+  if aura and aura.duration and aura.duration > 0 and aura.expirationTime then
     CooldownFrame_Set(frame.cooldown, aura.expirationTime - aura.duration, aura.duration, true)
-    if frame.overlay and frame.cooldown then
-      local need = frame.cooldown:GetFrameLevel() + 1
-      if frame.overlay:GetFrameLevel() <= need then
-        frame.overlay:SetFrameLevel(need)
-      end
-    end
   else
     CooldownFrame_Clear(frame.cooldown)
   end
@@ -721,470 +116,333 @@ local function PopulateBuffIconFrame(frame, buffID, aura, entry)
     frame.count:Hide()
   end
 
-  frame:Show()
-end
-
-local function ConfigureTrackedBarFrame(frame, entry, config)
-  frame:SetParent(EnsureAttachment("TRACKED_BARS") or UI.anchor)
-
-  frame.snapshotEntry = entry
-  frame.config = config
-
-  local candidates = CollectAuraSpellIDs(entry, frame.buffID)
-  local displaySpellID, displayName, displayIcon = ClassHUD:ResolveTrackedBarDisplay(entry, frame.buffID, candidates)
-
-  frame.auraSpellIDs = candidates
-  frame.displaySpellID = displaySpellID
-  frame.cooldownSpellID = (entry and entry.spellID) or frame.buffID
-
-  local color = CopyColor(config.barColor) or CopyColor(ClassHUD:GetDefaultTrackedBarColor())
-  frame._activeColor = color
-  frame._inactiveColor = frame._inactiveColor or CopyColor(INACTIVE_BAR_COLOR)
-
-  frame:SetStatusBarColor(color.r, color.g, color.b, color.a)
-
-  frame.label:SetFont(ClassHUD:FetchFont(12))
-  frame.timer:SetFont(ClassHUD:FetchFont(12))
-  if frame.stacks then
-    frame.stacks:SetFont(ClassHUD:FetchFont(12))
-    frame.stacks:Hide()
-  end
-
-  frame.defaultLabel = displayName
-  frame.label:SetText(displayName)
-
-  local iconID = displayIcon or (displaySpellID and C_Spell.GetSpellTexture(displaySpellID))
-  if not iconID then
-    iconID = entry and entry.iconID
-  end
-  if not iconID and frame.buffID then
-    iconID = C_Spell.GetSpellTexture(frame.buffID)
-  end
-
-  local height = ClassHUD.db.profile.trackedBuffBar.height or 16
-
-  if config.barShowIcon ~= false then
-    frame.icon:SetTexture(iconID or 134400)
-    frame.icon:SetSize(height, height)
-    frame.icon:Show()
-    frame.icon:ClearAllPoints()
-    frame.icon:SetPoint("LEFT", frame, "LEFT", 0, 0)
-    frame.label:ClearAllPoints()
-    frame.label:SetPoint("LEFT", frame.icon, "RIGHT", 4, 0)
-  else
-    frame.icon:Hide()
-    frame.label:ClearAllPoints()
-    frame.label:SetPoint("LEFT", frame, "LEFT", 4, 0)
-  end
-
-  frame._showTimer = config.barShowTimer ~= false
-  if not frame._showTimer and frame.timer then
-    frame.timer:Hide()
-  end
-  if frame.timer then
-    frame.timer:ClearAllPoints()
-    frame.timer:SetPoint("TOPRIGHT", frame, "TOPRIGHT", -4, -2)
-  end
-end
-
-local function UpdateTrackedBarFrame(frame)
-  local buffID = frame.buffID
-  if not buffID then return false end
-
-  local aura, auraSpellID = FindAuraFromCandidates(frame.auraSpellIDs)
   if aura then
-    frame:Show()
+    frame.icon:SetDesaturated(false)
+    frame.icon:SetVertexColor(1, 1, 1, 1)
+  else
+    frame.icon:SetDesaturated(true)
+    frame.icon:SetVertexColor(0.7, 0.7, 0.7, 1)
+  end
+end
 
-    local texture = aura.icon or (auraSpellID and C_Spell.GetSpellTexture(auraSpellID))
-    if frame.icon and frame.icon:IsShown() and texture then
-      frame.icon:SetTexture(texture)
+local function ApplyCooldownVisuals(frame, entry, info)
+  local spellID = entry.spellID or entry.buffID
+  local start, duration, charges, iconID = ExtractCooldown(info, spellID)
+
+  if iconID then
+    frame.icon:SetTexture(iconID)
+  elseif spellID then
+    local tex = C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(spellID)
+    if tex then frame.icon:SetTexture(tex) end
+  end
+
+  if start and duration and duration > 0 then
+    CooldownFrame_Set(frame.cooldown, start, duration, true)
+  else
+    CooldownFrame_Clear(frame.cooldown)
+  end
+
+  if charges and charges > 1 then
+    frame.count:SetText(charges)
+    frame.count:Show()
+  else
+    frame.count:SetText("")
+    frame.count:Hide()
+  end
+
+  frame.icon:SetDesaturated(duration and duration > 0)
+  frame.icon:SetVertexColor(1, 1, 1, 1)
+end
+
+local function UpdateBuffFrame(entry)
+  local buffID = entry.buffID
+  if not buffID then return nil end
+
+  local frame = AcquireBuffFrame(buffID)
+  frame.buffID = buffID
+  frame.entry = entry
+
+  local aura, auraSpellID
+  if entry.auraCandidates == nil then
+    local snapshot = entry.snapshot
+    if not snapshot then
+      snapshot = ClassHUD:GetSnapshotEntry(entry.snapshotSpellID or buffID)
     end
+    entry.auraCandidates = ClassHUD:GetAuraCandidatesForEntry(snapshot, buffID)
+  end
 
-    local displayName = aura.name or (auraSpellID and C_Spell.GetSpellName(auraSpellID)) or frame.defaultLabel
-    if displayName then
-      frame.label:SetText(displayName)
+  if entry.auraCandidates and #entry.auraCandidates > 0 then
+    aura, auraSpellID = ClassHUD:FindAuraFromCandidates(entry.auraCandidates, TRACKED_UNITS)
+  end
+
+  if not aura then
+    aura, auraSpellID = ClassHUD:GetAuraForSpell(buffID, TRACKED_UNITS)
+  end
+
+  if aura then
+    ApplyAuraVisuals(frame, aura, auraSpellID)
+  elseif entry.isTrackedBar then
+    local info
+    if C_CooldownViewer and C_CooldownViewer.GetCooldownViewerCooldownInfo and entry.cooldownID then
+      info = C_CooldownViewer.GetCooldownViewerCooldownInfo(entry.cooldownID)
     end
+    ApplyCooldownVisuals(frame, entry, info)
+  else
+    frame.icon:SetTexture(entry.iconID or (C_Spell and C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(buffID)) or 134400)
+    ApplyAuraVisuals(frame, nil, nil)
+  end
 
-    local stacks = aura.applications or aura.stackCount or aura.charges
-    stacks = tonumber(stacks)
-    if frame.stacks then
-      if stacks and stacks > 1 then
-        frame.stacks:SetText(tostring(stacks))
-        frame.stacks:Show()
+  frame:Show()
+  return frame
+end
+
+local function SortEntries(entries)
+  table.sort(entries, function(a, b)
+    if a.order and b.order and a.order ~= b.order then
+      return a.order < b.order
+    end
+    return (a.name or "") < (b.name or "")
+  end)
+end
+
+function ClassHUD:BuildTrackedBuffsFromBlizzard()
+  local results = {}
+
+  if not (C_CooldownViewer and Enum and Enum.CooldownViewerCategory) then
+    return results
+  end
+
+  local class, specID = self:GetPlayerClassSpec()
+  local snapshot = self:GetSnapshotForSpec(class, specID, false)
+
+  local category = Enum.CooldownViewerCategory.TrackedBuffs
+  local ids = C_CooldownViewer.GetCooldownViewerCategorySet and C_CooldownViewer.GetCooldownViewerCategorySet(category)
+  if type(ids) ~= "table" then
+    return results
+  end
+
+  for index, cooldownID in ipairs(ids) do
+    local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cooldownID)
+    if info then
+      local spellID = info.spellID or info.overrideSpellID
+      if not spellID and type(info.linkedSpellIDs) == "table" then
+        spellID = info.linkedSpellIDs[1]
+      end
+
+      if spellID then
+        local spellInfo = C_Spell.GetSpellInfo(spellID)
+        table.insert(results, {
+          buffID = spellID,
+          spellID = spellID,
+          cooldownID = cooldownID,
+          iconID = spellInfo and spellInfo.iconID,
+          name = spellInfo and spellInfo.name,
+          order = index,
+          source = "trackedBuff",
+          snapshot = snapshot and snapshot[spellID] or nil,
+          snapshotSpellID = spellID,
+        })
+      end
+    end
+  end
+
+  return results
+end
+
+function ClassHUD:BuildTrackedBarsAsBuffs()
+  local results = {}
+
+  if not (C_CooldownViewer and Enum and Enum.CooldownViewerCategory) then
+    return results
+  end
+
+  local class, specID = self:GetPlayerClassSpec()
+  local snapshot = self:GetSnapshotForSpec(class, specID, false)
+
+  local category = Enum.CooldownViewerCategory.TrackedBars
+  local ids = C_CooldownViewer.GetCooldownViewerCategorySet and C_CooldownViewer.GetCooldownViewerCategorySet(category)
+  if type(ids) ~= "table" then
+    return results
+  end
+
+  for index, cooldownID in ipairs(ids) do
+    local info = C_CooldownViewer.GetCooldownViewerCooldownInfo(cooldownID)
+    if info then
+      local spellID = info.spellID or info.overrideSpellID
+      if not spellID and type(info.linkedSpellIDs) == "table" then
+        spellID = info.linkedSpellIDs[1]
+      end
+
+      if spellID then
+        local spellInfo = C_Spell.GetSpellInfo(spellID)
+        table.insert(results, {
+          buffID = spellID,
+          spellID = spellID,
+          cooldownID = cooldownID,
+          iconID = spellInfo and spellInfo.iconID,
+          name = spellInfo and spellInfo.name,
+          order = 1000 + index,
+          source = "trackedBar",
+          snapshot = snapshot and snapshot[spellID] or nil,
+          snapshotSpellID = spellID,
+          isTrackedBar = true,
+        })
+      end
+    end
+  end
+
+  return results
+end
+
+local function CollectCustomEntries(addon)
+  local results = {}
+  local class, specID = addon:GetPlayerClassSpec()
+  local custom = addon:GetCustomTrackedBuffs(class, specID, false)
+  if not custom then return results end
+
+  for spellID in pairs(custom) do
+    local spellInfo = C_Spell.GetSpellInfo(spellID)
+    table.insert(results, {
+      buffID = spellID,
+      spellID = spellID,
+      iconID = spellInfo and spellInfo.iconID,
+      name = spellInfo and spellInfo.name,
+      order = 2000 + spellID,
+      source = "custom",
+      snapshot = nil,
+      snapshotSpellID = spellID,
+    })
+  end
+
+  return results
+end
+
+local function CollectVisibleEntries(addon)
+  local class, specID = addon:GetPlayerClassSpec()
+  local hidden = addon:GetHiddenTrackedBuffs(class, specID, false) or {}
+
+  local byID, ordered = {}, {}
+
+  for _, entry in ipairs(addon:BuildTrackedBuffsFromBlizzard()) do
+    if not hidden[entry.buffID] then
+      byID[entry.buffID] = entry
+      table.insert(ordered, entry)
+    end
+  end
+
+  for _, entry in ipairs(addon:BuildTrackedBarsAsBuffs()) do
+    if not hidden[entry.buffID] then
+      local existing = byID[entry.buffID]
+      if existing then
+        existing.isTrackedBar = true
+        existing.cooldownID = existing.cooldownID or entry.cooldownID
+        existing.iconID = existing.iconID or entry.iconID
       else
-        frame.stacks:SetText("")
-        frame.stacks:Hide()
+        byID[entry.buffID] = entry
+        table.insert(ordered, entry)
       end
     end
+  end
 
-    frame:SetStatusBarColor(frame._activeColor.r, frame._activeColor.g, frame._activeColor.b, frame._activeColor.a)
+  for _, entry in ipairs(CollectCustomEntries(addon)) do
+    if not hidden[entry.buffID] and not byID[entry.buffID] then
+      byID[entry.buffID] = entry
+      table.insert(ordered, entry)
+    end
+  end
 
-    if aura.duration and aura.duration > 0 and aura.expirationTime then
-      frame._duration = aura.duration
-      frame._expiration = aura.expirationTime
-      frame:SetMinMaxValues(0, aura.duration)
-      frame:SetValue(math.max(0, aura.expirationTime - GetTime()))
-      frame:SetScript("OnUpdate", OnTrackedBarUpdate)
-      OnTrackedBarUpdate(frame)
+  SortEntries(ordered)
+  return ordered
+end
+
+local function LayoutTrackedIcons(frames)
+  local container = EnsureBuffContainer()
+  local settings = ClassHUD.db.profile.trackedBuffBar or {}
+  local width = ClassHUD.db.profile.width or 250
+  local perRow = math.max(settings.perRow or 8, 1)
+  local spacingX = settings.spacingX or 4
+  local spacingY = settings.spacingY or 4
+  local offsetX = settings.offsetX or 0
+  local offsetY = settings.offsetY or 8
+  local align = settings.align or "CENTER"
+
+  container:ClearAllPoints()
+  local anchor = (UI.attachments and UI.attachments.CAST) or UI.anchor
+  container:SetPoint("BOTTOM", anchor, "TOP", offsetX, offsetY)
+  container:SetWidth(width)
+
+  if #frames == 0 then
+    container:SetHeight(1)
+    container:Hide()
+    return
+  end
+
+  local size = math.floor((width - (perRow - 1) * spacingX) / perRow + 0.5)
+  if size < 16 then size = 16 end
+
+  local rows = math.ceil(#frames / perRow)
+
+  for index, frame in ipairs(frames) do
+    frame:SetParent(container)
+    frame:ClearAllPoints()
+    frame:SetSize(size, size)
+
+    local row = math.floor((index - 1) / perRow)
+    local col = (index - 1) % perRow
+    local iconsInRow = math.min(perRow, #frames - row * perRow)
+    local rowWidth = iconsInRow * size + math.max(0, iconsInRow - 1) * spacingX
+
+    local x
+    if align == "LEFT" then
+      x = col * (size + spacingX)
+    elseif align == "RIGHT" then
+      x = (width - rowWidth) + col * (size + spacingX)
     else
-      frame._duration = nil
-      frame._expiration = nil
-      frame:SetMinMaxValues(0, 1)
-      frame:SetValue(1)
-      frame:SetScript("OnUpdate", nil)
-      if frame.timer then
-        frame.timer:SetText("")
-        frame.timer:Hide()
-      end
+      local start = (width - rowWidth) / 2
+      x = start + col * (size + spacingX)
     end
 
-    return true
+    frame:SetPoint("BOTTOMLEFT", container, "BOTTOMLEFT", x, row * (size + spacingY))
   end
 
-  frame._duration = nil
-  frame._expiration = nil
-  frame:SetMinMaxValues(0, 1)
-  frame:SetValue(0)
-  frame:SetStatusBarColor(frame._inactiveColor.r, frame._inactiveColor.g, frame._inactiveColor.b, frame._inactiveColor.a)
-  frame:SetScript("OnUpdate", nil)
-
-  if frame.timer then
-    frame.timer:SetText("")
-    frame.timer:Hide()
-  end
-  if frame.stacks then
-    frame.stacks:SetText("")
-    frame.stacks:Hide()
-  end
-
-  if frame.defaultLabel then
-    frame.label:SetText(frame.defaultLabel)
-  end
-
-  frame:Hide()
-  return false
+  local totalHeight = rows * size + math.max(0, rows - 1) * spacingY
+  container:SetHeight(totalHeight)
+  container:Show()
 end
 
 function ClassHUD:BuildTrackedBuffFrames()
-  if self.trackedBuffFrames then
-    for _, frame in ipairs(self.trackedBuffFrames) do
-      frame:Hide()
-    end
+  local container = EnsureBuffContainer()
+
+  for _, frame in ipairs(activeFrames) do
+    ResetFrame(frame)
   end
-  if self.trackedBarFrames then
-    for _, frame in ipairs(self.trackedBarFrames) do
-      frame:Hide()
-      frame:SetScript("OnUpdate", nil)
-    end
-  end
+  wipe(activeFrames)
 
-  wipe(self.trackedBuffFrames)
-  wipe(self.trackedBarFrames)
-
-  EnsureAttachment("TRACKED_ICONS")
-  EnsureAttachment("TRACKED_BARS")
-
-  local function resetLayouts()
-    LayoutTrackedBars({}, nil)
-    LayoutTrackedIcons({}, nil)
-    if self.Layout then self:Layout() end
-  end
-
-  if not self.db.profile.show.buffs then
-    resetLayouts()
+  if not (self.db and self.db.profile and self.db.profile.show and self.db.profile.show.buffs) then
+    container:Hide()
     return
   end
 
-  local class, specID = self:GetPlayerClassSpec()
-  if not specID or specID == 0 then
-    resetLayouts()
+  local entries = CollectVisibleEntries(self)
+  if #entries == 0 then
+    container:Hide()
     return
   end
 
-  local tracked = self:GetProfileTable(false, "trackedBuffs", class, specID)
-  if not tracked then
-    resetLayouts()
-    return
-  end
-
-  local snapshot = self:GetSnapshotForSpec(class, specID, false)
-  local ordered = {}
-
-  for buffID, _ in pairs(tracked) do
-    local config = self:GetTrackedEntryConfig(class, specID, buffID, false)
-    if config then
-      local entry = snapshot and snapshot[buffID]
-      local order = math.huge
-      if entry and entry.categories then
-        if entry.categories.bar and entry.categories.bar.order then
-          order = math.min(order, entry.categories.bar.order)
-        end
-        if entry.categories.buff and entry.categories.buff.order then
-          order = math.min(order, entry.categories.buff.order)
-        end
-      end
-      local name = entry and entry.name or C_Spell.GetSpellName(buffID) or ("Spell " .. buffID)
-      table.insert(ordered, {
-        buffID = buffID,
-        config = config,
-        entry = entry,
-        order = order,
-        name = name,
-      })
+  for _, entry in ipairs(entries) do
+    local frame = UpdateBuffFrame(entry)
+    if frame then
+      table.insert(activeFrames, frame)
     end
   end
 
-  table.sort(ordered, function(a, b)
-    if a.order == b.order then
-      return a.name < b.name
-    end
-    return a.order < b.order
-  end)
-
-  local iconFrames = {}
-  local barFrames = {}
-
-  for _, info in ipairs(ordered) do
-    local buffID = info.buffID
-    local config = info.config
-    local entry = info.entry
-    local auraCandidates = CollectAuraSpellIDs(entry, buffID)
-
-    if config.showIcon then
-      local aura = FindAuraFromCandidates(auraCandidates)
-      if aura then
-        local iconFrame = CreateBuffFrame(buffID)
-        PopulateBuffIconFrame(iconFrame, buffID, aura, entry)
-        table.insert(iconFrames, iconFrame)
-      end
-    end
-  end
-
-  self.trackedBuffFrames = iconFrames
-  self.trackedBarFrames = barFrames
-  local settings = self.db.profile.trackedBuffBar or {}
-  local yOffset = settings.yOffset or 0
-
-  local barTopPadding = (#barFrames > 0) and yOffset or 0
-  local iconTopPadding = (#barFrames == 0 and #iconFrames > 0) and yOffset or 0
-  LayoutTrackedBars(barFrames, { topPadding = barTopPadding })
-  LayoutTrackedIcons(iconFrames, { topPadding = iconTopPadding })
-
-  if self.Layout then
-    self:Layout()
-  end
+  LayoutTrackedIcons(activeFrames)
 end
-
--- ==================================================
--- UpdateSpellFrame
--- ==================================================
-local function UpdateSpellFrame(frame)
-  local sid = frame.spellID
-  if not sid then return end
-
-  local data = ClassHUD.cdmSpells and ClassHUD.cdmSpells[sid]
-  local entry = ClassHUD:GetSnapshotEntry(sid)
-
-  -- Ikon
-  UpdateSpellIcon(frame, sid, entry)
-
-
-  -- Aura
-  local auraID
-  if data then
-    if data.buff then
-      auraID = data.buff.overrideSpellID
-          or (data.buff.linkedSpellIDs and data.buff.linkedSpellIDs[1])
-          or data.buff.spellID
-    elseif data.bar then
-      auraID = data.bar.overrideSpellID
-          or (data.bar.linkedSpellIDs and data.bar.linkedSpellIDs[1])
-          or data.bar.spellID
-    end
-  end
-  auraID = auraID or sid
-
-  local aura = ClassHUD:GetAuraForSpell(auraID)
-  -- Cooldown & charges
-  local chargesShown, gcdActive = UpdateCooldown(frame, sid, false)
-
-  UpdateAuraOverlay(frame, aura, chargesShown)
-
-  -- Glow
-  UpdateGlow(frame, aura, sid, data)
-  -- Tekst
-  UpdateCooldownText(frame, gcdActive)
-end
-
--- ==================================================
--- Public API (kalles fra ClassHUD.lua events)
--- ==================================================
-ClassHUD.UpdateTrackedBarFrame = UpdateTrackedBarFrame
 
 function ClassHUD:UpdateAllFrames()
-  self:RefreshSnapshotCache()
-  for _, f in ipairs(activeFrames) do
-    UpdateSpellFrame(f)
-  end
-
-  if self.BuildTrackedBuffFrames then
-    self:BuildTrackedBuffFrames()
-  end
-
-  -- Før auto-map, håndter manuelle buffLinks fra DB
-  local class, specID = self:GetPlayerClassSpec()
-  if not specID or specID == 0 then
-    return
-  end
-
-  local links = (ClassHUD.db.profile.buffLinks[class] and ClassHUD.db.profile.buffLinks[class][specID]) or {}
-
-  for buffID, spellID in pairs(links) do
-    local aura = C_UnitAuras.GetPlayerAuraBySpellID and C_UnitAuras.GetPlayerAuraBySpellID(buffID)
-    if not aura and UnitExists("pet") and C_UnitAuras and C_UnitAuras.GetAuraDataBySpellID then
-      aura = C_UnitAuras.GetAuraDataBySpellID("pet", buffID)
-    end
-  end
+  self:BuildTrackedBuffFrames()
 end
 
 function ClassHUD:BuildFramesForSpec()
-  for _, f in ipairs(activeFrames) do f:Hide() end
-  wipe(activeFrames)
-
-  if self.spellFrames then
-    for _, frame in pairs(self.spellFrames) do
-      frame.snapshotEntry = nil
-    end
-  end
-
-  self.trackedBuffToSpell = {}
-
-  local class, specID = self:GetPlayerClassSpec()
-  if not specID or specID == 0 then
-    return
-  end
-
-  local snapshot = self:GetSnapshotForSpec(class, specID, false)
-  if not snapshot or next(snapshot) == nil then
-    self.cdmSpells = {}
-    return
-  end
-
-  self:RefreshSnapshotCache()
-
-  local built = {}
-
-  local function acquire(spellID)
-    local frame = CreateSpellFrame(spellID)
-    frame:Show()
-    frame.snapshotEntry = snapshot[spellID]
-    if not built[spellID] then
-      table.insert(activeFrames, frame)
-      built[spellID] = true
-    end
-    return frame
-  end
-
-  local function collect(category)
-    local list = {}
-    self:ForEachSnapshotEntry(category, function(spellID, entry, categoryData)
-      table.insert(list, { spellID = spellID, entry = entry, data = categoryData })
-    end)
-    table.sort(list, function(a, b)
-      local ao = (a.data and a.data.order) or math.huge
-      local bo = (b.data and b.data.order) or math.huge
-      if ao == bo then
-        return (a.entry.name or "") < (b.entry.name or "")
-      end
-      return ao < bo
-    end)
-    return list
-  end
-
-  local class, specID = self:GetPlayerClassSpec()
-  self.db.profile.utilityPlacement[class] = self.db.profile.utilityPlacement[class] or {}
-  self.db.profile.utilityPlacement[class][specID] = self.db.profile.utilityPlacement[class][specID] or {}
-
-  local placements = self.db.profile.utilityPlacement[class][specID]
-
-
-  local topFrames, bottomFrames = {}, {}
-  local sideFrames = { LEFT = {}, RIGHT = {} }
-
-  local function placeSpell(spellID, defaultPlacement)
-    if built[spellID] then return end
-
-    local placement = placements[spellID] or defaultPlacement or "TOP"
-    if placement == "HIDDEN" then
-      built[spellID] = true
-      return
-    end
-
-    local frame = acquire(spellID)
-    if placement == "TOP" then
-      table.insert(topFrames, frame)
-    elseif placement == "BOTTOM" then
-      table.insert(bottomFrames, frame)
-    elseif placement == "LEFT" or placement == "RIGHT" then
-      table.insert(sideFrames[placement], frame)
-    else
-      table.insert(topFrames, frame)
-    end
-  end
-
-  for _, item in ipairs(collect("essential")) do
-    placeSpell(item.spellID, "TOP")
-  end
-
-  for _, item in ipairs(collect("utility")) do
-    placeSpell(item.spellID, "HIDDEN")
-  end
-
-  -- for _, item in ipairs(collect("bar")) do
-  --   placeSpell(item.spellID, "BOTTOM")
-  -- end
-
-  for spellID, placement in pairs(placements) do
-    if not built[spellID] then
-      placeSpell(spellID, placement)
-    end
-  end
-
-  LayoutTopBar(topFrames)
-  LayoutBottomBar(bottomFrames)
-  if #sideFrames.LEFT > 0 then LayoutSideBar(sideFrames.LEFT, "LEFT") end
-  if #sideFrames.RIGHT > 0 then LayoutSideBar(sideFrames.RIGHT, "RIGHT") end
-
-  -- Auto-map tracked buffs to spells using snapshot descriptions
-  self.db.profile.buffLinks = self.db.profile.buffLinks or {}
-  self.db.profile.buffLinks[class] = self.db.profile.buffLinks[class] or {}
-  self.db.profile.buffLinks[class][specID] = self.db.profile.buffLinks[class][specID] or {}
-
-  for buffID, entry in pairs(snapshot) do
-    if entry.categories and entry.categories.buff then
-      local desc = entry.desc or C_Spell.GetSpellDescription(buffID)
-      if desc then
-        for spellID, frame in pairs(self.spellFrames) do
-          if frame and frame.snapshotEntry then
-            local spellName = C_Spell.GetSpellName(spellID)
-            if spellName and string.find(desc, spellName, 1, true) then
-              self.trackedBuffToSpell[buffID] = spellID
-
-              local links = self.db.profile.buffLinks[class][specID]
-              if not links[buffID] then
-                links[buffID] = spellID
-              end
-              break
-            end
-          end
-        end
-      end
-    end
-  end
-
-  self:UpdateAllFrames()
-
-  if self.Layout then
-    self:Layout()
-  end
+  self:BuildTrackedBuffFrames()
 end


### PR DESCRIPTION
## Summary
- enable Blizzard's cooldown viewer, anchor the HUD to EssentialCooldownViewer, and refresh the saved defaults for offsets and font sizes
- replace the internal spell bar builders with a tracked-buff icon system that pulls from Blizzard cooldown categories and user custom entries
- rebuild the configuration UI around the new buff workflow and add helper utilities for hiding/showing entries per spec

## Testing
- not run (luac unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ceb7e4b25883218b58e28266cbef98