### PR TITLE
Refactor HUD bar system to use profile-driven layout

### DIFF
--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -96,7 +96,7 @@ local defaults = {
       bar  = "Blizzard",
       font = "Friz Quadrata TT",
     },
-    barOrder         = { "cast", "health", "resource", "class" },
+    barOrder         = { "top", "cast", "health", "resource", "class", "bottom" },
     show             = {
       cast     = true,
       hp       = true,

--- a/ClassHUD.toc
+++ b/ClassHUD.toc
@@ -13,6 +13,7 @@ ClassHUD.lua
 ClassHUD_Utils.lua
 ClassHUD_Bars.lua
 ClassHUD_Classbar.lua
+ClassHUD_Eclipse.lua
 ClassHUD_Spells.lua
 ClassHUD_Options.lua
 ClassHUD_SpellSuggestions.lua

--- a/ClassHUD_Classbar.lua
+++ b/ClassHUD_Classbar.lua
@@ -3,8 +3,6 @@
 local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
 local UI = ClassHUD.UI
 
--- ========= Advanced Class Resource System =========
-
 -- Map classes → special resource power types
 local CLASS_POWER_ID = {
   MONK        = Enum.PowerType.Chi,
@@ -25,13 +23,13 @@ local REQUIRED_SPEC = {
 
 -- Specs that use partial resource (e.g., Destruction shards)
 local USES_PARTIAL_BY_SPEC = {
-  [267] = true, -- Warlock Destruction
+  [267] = true, -- Destruction Warlock shards
 }
 
 -- Charged Combo Points highlight color (Rogue)
 local CHARGED_CP_COLOR = { 1.0, 0.95, 0.35 }
 
--- Base resource colors
+-- Base resource colors for themed powers
 local RESOURCE_BASE_COLORS = {
   [Enum.PowerType.HolyPower]     = { 1.00, 0.88, 0.25 },
   [Enum.PowerType.SoulShards]    = { 0.60, 0.22, 1.00 },
@@ -39,7 +37,6 @@ local RESOURCE_BASE_COLORS = {
   [Enum.PowerType.Essence]       = { 0.50, 1.00, 0.90 },
 }
 
--- DK rune colors by spec
 local function RuneSpecColor(specID)
   if specID == 250 then return 0.75, 0.10, 0.10 end -- Blood
   if specID == 251 then return 0.35, 0.70, 1.00 end -- Frost
@@ -47,7 +44,6 @@ local function RuneSpecColor(specID)
   return 0.7, 0.7, 0.7
 end
 
--- Per-index color for CP/Chi/Arcane
 local function IndexedColor(i, max)
   if max <= 1 then return 1, 1, 1 end
   local t = (i - 1) / (max - 1)
@@ -57,196 +53,248 @@ local function IndexedColor(i, max)
   return r, g, b
 end
 
--- Get charged CP indices (Rogue)
 local function GetChargedPoints()
   if not GetUnitChargedPowerPoints then return nil end
   return GetUnitChargedPowerPoints("player")
 end
 
-local function SegmentColor(i, max, ptype, class, specID, chargedPoints)
-  if ptype == Enum.PowerType.Runes then
-    return RuneSpecColor(specID)
+local function EnsureSegment(addon, index)
+  local bar = addon.bars and addon.bars.class
+  if not bar then return nil end
+  bar.segments = bar.segments or {}
+  local segment = bar.segments[index]
+  if not segment then
+    segment = CreateFrame("StatusBar", nil, bar)
+    segment:SetMinMaxValues(0, 1)
+    segment.bg = segment:CreateTexture(nil, "BACKGROUND")
+    segment.bg:SetAllPoints(segment)
+    segment.bg:SetColorTexture(0, 0, 0, 0.6)
+    bar.segments[index] = segment
   end
-  if ptype == Enum.PowerType.ComboPoints or ptype == Enum.PowerType.Chi or ptype == Enum.PowerType.ArcaneCharges then
-    if ptype == Enum.PowerType.ComboPoints and chargedPoints then
-      for _, idx in ipairs(chargedPoints) do
-        if idx == i then return unpack(CHARGED_CP_COLOR) end
-      end
+  segment:SetStatusBarTexture(addon:FetchStatusbar())
+  segment.bg:SetAllPoints(segment)
+  return segment
+end
+
+local function HideSegments(addon, from)
+  local bar = addon.bars and addon.bars.class
+  if not bar or not bar.segments then return end
+  for i = from, #bar.segments do
+    if bar.segments[i] then bar.segments[i]:Hide() end
+  end
+end
+
+local function LayoutSegments(addon, count)
+  local bar = addon.bars and addon.bars.class
+  if not bar then return end
+  if count <= 0 then
+    HideSegments(addon, 1)
+    bar:Hide()
+    return
+  end
+
+  local profile = addon.db and addon.db.profile or {}
+  local width = profile.width or 250
+  local spacing = profile.powerSpacing
+  if spacing == nil then spacing = profile.spacing or 0 end
+  local height = (profile.height and profile.height.class) or 14
+  local segWidth = (width - spacing * (count - 1)) / count
+  if segWidth < 1 then segWidth = 1 end
+
+  for i = 1, count do
+    local segment = EnsureSegment(addon, i)
+    segment:SetSize(segWidth, height)
+    segment:ClearAllPoints()
+    if i == 1 then
+      segment:SetPoint("LEFT", bar, "LEFT", 0, 0)
+    else
+      segment:SetPoint("LEFT", bar.segments[i - 1], "RIGHT", spacing, 0)
     end
-    return IndexedColor(i, max)
+    segment:SetMinMaxValues(0, 1)
+    segment:Show()
   end
-  local base = RESOURCE_BASE_COLORS[ptype]
-  if base then return unpack(base) end
-  return ClassHUD:PowerColorBy(ptype)
+
+  HideSegments(addon, count + 1)
+  bar:Show()
 end
 
-local function EnsureSegment(i)
-  if not UI.powerSegments[i] then
-    local sb = ClassHUD:CreateStatusBar(UI.power, ClassHUD.db.profile.height.power)
-    sb.text:Hide() -- segments don’t need text
-    UI.powerSegments[i] = sb
+local function SegmentColor(ptype, index, max, chargedLookup)
+  if ptype == Enum.PowerType.ComboPoints and chargedLookup and chargedLookup[index] then
+    return unpack(CHARGED_CP_COLOR)
   end
-  return UI.powerSegments[i]
+
+  if RESOURCE_BASE_COLORS[ptype] then
+    local color = RESOURCE_BASE_COLORS[ptype]
+    return color[1], color[2], color[3]
+  end
+
+  return IndexedColor(index, max)
 end
 
-local function HideAllSegments(from)
-  for i = from, #UI.powerSegments do
-    if UI.powerSegments[i] then UI.powerSegments[i]:Hide() end
+local function UpdateSegments(addon, ptype, max, specID)
+  if max <= 0 then
+    HideSegments(addon, 1)
+    if addon.bars and addon.bars.class then addon.bars.class:Hide() end
+    return
   end
-end
 
--- Advanced segment updater
-function ClassHUD:UpdateSegmentsAdvanced(ptype, max, partial)
-  local w = self.db.profile.width
-  local gap = self.db.profile.powerSpacing or 1
-  local segW = (w - gap * (max - 1)) / max
+  LayoutSegments(addon, max)
 
-  local _, class = UnitClass("player")
-  local spec = GetSpecialization()
-  local specID = spec and GetSpecializationInfo(spec) or 0
-  local charged = (ptype == Enum.PowerType.ComboPoints and class == "ROGUE") and GetChargedPoints() or nil
-  local cur = UnitPower("player", ptype, partial and true or false)
+  local bar = addon.bars and addon.bars.class
+  if not bar then return end
 
-  local whole, frac = 0, 0
-  if partial then
-    local mod   = UnitPowerDisplayMod(ptype) or 1
-    local exact = cur / mod
-    whole       = math.floor(exact)
-    frac        = exact - whole
+  local charged = (ptype == Enum.PowerType.ComboPoints) and GetChargedPoints() or nil
+  local chargedLookup
+  if charged then
+    chargedLookup = {}
+    for _, idx in ipairs(charged) do
+      chargedLookup[idx] = true
+    end
   end
+
+  local usesPartial = USES_PARTIAL_BY_SPEC[specID] or false
+  local current = UnitPower("player", ptype, usesPartial and true or false)
+  local mod = UnitPowerDisplayMod and UnitPowerDisplayMod(ptype) or 1
+  local exact = usesPartial and (current / mod) or current
+  local whole = usesPartial and math.floor(exact) or exact
+  local frac = usesPartial and (exact - whole) or 0
 
   for i = 1, max do
-    local sb = EnsureSegment(i)
-    sb:SetStatusBarTexture(self:FetchStatusbar())
-    sb:SetSize(segW, self.db.profile.height.power)
-    sb:ClearAllPoints()
-    if i == 1 then
-      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
-    else
-      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
-    end
-    local r, g, b = SegmentColor(i, max, ptype, class, specID, charged)
-    sb:SetStatusBarColor(r, g, b)
-    sb:SetMinMaxValues(0, 1)
-    sb:Show()
+    local segment = EnsureSegment(addon, i)
+    local r, g, b = SegmentColor(ptype, i, max, chargedLookup)
+    segment:SetStatusBarColor(r, g, b)
 
-    if partial then
+    if usesPartial then
       if i <= whole then
-        sb:SetValue(1)
+        segment:SetValue(1)
       elseif i == whole + 1 then
-        sb:SetValue(frac)
+        segment:SetValue(frac)
       else
-        sb:SetValue(0)
+        segment:SetValue(0)
       end
     else
-      sb:SetValue(cur >= i and 1 or 0)
+      segment:SetValue(exact >= i and 1 or 0)
     end
+    segment:Show()
   end
-  HideAllSegments(max + 1)
+
+  bar:Show()
 end
 
--- Essence updater (with fractional preview)
-function ClassHUD:UpdateEssenceSegments(ptype)
+local function UpdateRunes(addon, specID)
+  local bar = addon.bars and addon.bars.class
+  if not bar then return end
+  LayoutSegments(addon, 6)
+
+  local r, g, b = RuneSpecColor(specID)
+  for i = 1, 6 do
+    local segment = EnsureSegment(addon, i)
+    local start, duration, ready = GetRuneCooldown(i)
+    if ready or not start or duration == 0 then
+      segment:SetValue(1)
+      segment:SetStatusBarColor(r, g, b)
+    else
+      local progress = (GetTime() - start) / duration
+      segment:SetValue(math.min(progress, 1))
+      segment:SetStatusBarColor(r * 0.6, g * 0.6, b * 0.6)
+    end
+    segment:Show()
+  end
+
+  bar:Show()
+end
+
+local function UpdateEssence(addon, ptype)
+  local bar = addon.bars and addon.bars.class
+  if not bar then return end
   local max = UnitPowerMax("player", ptype)
   if not max or max <= 0 then
-    HideAllSegments(1); UI.power:Hide(); return
+    HideSegments(addon, 1)
+    bar:Hide()
+    return
   end
-  local w = self.db.profile.width
-  local gap = self.db.profile.powerSpacing or 1
-  local segW = (w - gap * (max - 1)) / max
-  local cur = UnitPower("player", ptype)
+
+  LayoutSegments(addon, max)
+
+  local current = UnitPower("player", ptype)
   local partial = UnitPartialPower and (UnitPartialPower("player", ptype) or 0) or 0
-  local nextFrac = partial / 1000.0
-  local base = RESOURCE_BASE_COLORS[ptype] or { 0.5, 1, 0.9 }
-  local r, g, b = base[1], base[2], base[3]
+  local nextFrac = partial / 1000
+  local base = RESOURCE_BASE_COLORS[ptype] or { 0.5, 1.0, 0.9 }
+
   for i = 1, max do
-    local sb = EnsureSegment(i)
-    sb:SetStatusBarTexture(self:FetchStatusbar())
-    sb:SetSize(segW, self.db.profile.height.power)
-    sb:ClearAllPoints()
-    if i == 1 then
-      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
+    local segment = EnsureSegment(addon, i)
+    segment:SetStatusBarColor(base[1], base[2], base[3])
+    if i <= current then
+      segment:SetValue(1)
+    elseif i == current + 1 then
+      segment:SetValue(math.min(nextFrac, 1))
     else
-      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
+      segment:SetValue(0)
     end
-    sb:SetMinMaxValues(0, 1)
-    sb:SetStatusBarColor(r, g, b)
-    sb:Show()
-    if i <= cur then
-      sb:SetValue(1)
-    elseif i == cur + 1 and cur < max then
-      sb:SetValue(nextFrac)
-    else
-      sb:SetValue(0)
-    end
+    segment:Show()
   end
-  HideAllSegments(max + 1)
+
+  bar:Show()
 end
 
--- Resolve which special power to show
 local function ResolveSpecialPower()
   local _, class = UnitClass("player")
   local spec = GetSpecialization()
   local specID = spec and GetSpecializationInfo(spec) or 0
   local ptype = CLASS_POWER_ID[class]
-  if REQUIRED_SPEC[class] and specID ~= REQUIRED_SPEC[class] then return nil end
+  if not ptype then return nil end
+
+  if REQUIRED_SPEC[class] and specID ~= REQUIRED_SPEC[class] then
+    return nil
+  end
+
   if class == "DRUID" and select(1, UnitPowerType("player")) ~= Enum.PowerType.Energy then
     return nil
   end
+
   return ptype, specID
 end
 
--- Main update entry
-function ClassHUD:UpdateSpecialPower()
-  if not self.db.profile.show.power then return end
+function ClassHUD:UpdateClassBar()
+  if not self:IsBarEnabled("class") then
+    if self.bars and self.bars.class then
+      self.bars.class:Hide()
+      HideSegments(self, 1)
+    end
+    return
+  end
+
+  self:EnsureBars()
+
+  local bar = self.bars and self.bars.class
+  if not bar then return end
+
   local ptype, specID = ResolveSpecialPower()
   if not ptype then
-    HideAllSegments(1); UI.power:Hide(); return
+    HideSegments(self, 1)
+    bar:Hide()
+    return
   end
-  UI.power:Show()
+
+  bar:Show()
+  UI.power = bar
+
   if ptype == Enum.PowerType.Runes then
-    self:UpdateRunes()
-    return
-  elseif ptype == Enum.PowerType.Essence then
-    self:UpdateEssenceSegments(ptype)
+    UpdateRunes(self, specID)
     return
   end
+
+  if ptype == Enum.PowerType.Essence then
+    UpdateEssence(self, ptype)
+    return
+  end
+
   local max = UnitPowerMax("player", ptype) or 0
-  local usePartial = USES_PARTIAL_BY_SPEC[specID] or false
-  self:UpdateSegmentsAdvanced(ptype, max, usePartial)
+  UpdateSegments(self, ptype, max, specID)
 end
 
-function ClassHUD:UpdateRunes()
-  -- 6 runes; each rune shows its cooldown fill
-  local w = 250
-  local spec = GetSpecialization()
-  local specID = spec and GetSpecializationInfo(spec) or 0
-  local rr, rg, rb = RuneSpecColor and RuneSpecColor(specID) or 0.7, 0.7, 0.7
-  local gap = 2
-  local max = 6
-  local segW = (w - gap * (max - 1)) / max
-  for i = 1, max do
-    local sb = EnsureSegment(i)
-    sb:SetStatusBarTexture(self:FetchStatusbar())
-    sb:SetSize(segW, 16)
-    sb:ClearAllPoints()
-    if i == 1 then
-      sb:SetPoint("LEFT", UI.power, "LEFT", 0, 0)
-    else
-      sb:SetPoint("LEFT", UI.powerSegments[i - 1], "RIGHT", gap, 0)
-    end
-    local start, duration, ready = GetRuneCooldown(i)
-    sb:SetMinMaxValues(0, 1)
-    if ready then
-      sb:SetValue(1); sb:SetStatusBarColor(rr, rg, rb)
-    elseif start and duration and duration > 0 then
-      local elapsed = GetTime() - start
-      sb:SetValue(math.min(elapsed / duration, 1))
-      sb:SetStatusBarColor(rr * 0.5, rg * 0.5, rb * 0.5)
-    else
-      sb:SetValue(1); sb:SetStatusBarColor(rr, rg, rb)
-    end
-    sb:Show()
-  end
-  HideAllSegments(max + 1)
+-- Backwards compatibility for callers still using the old name
+function ClassHUD:UpdateSpecialPower()
+  self:UpdateClassBar()
 end
+

--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -565,14 +565,16 @@ local function BuildBarOrderEditor(addon, container)
   for k in pairs(container) do container[k] = nil end
 
   local db = addon.db
-  local order = addon.GetBarOrder and addon:GetBarOrder() or { "cast", "health", "resource", "class" }
+  local order = addon.GetBarOrder and addon:GetBarOrder() or { "top", "cast", "health", "resource", "class", "bottom" }
   db.profile.barOrder = { unpack(order) }
 
   local LABELS = {
-    cast    = "Cast Bar",
-    health  = "Health Bar",
+    top      = "Top Bar",
+    cast     = "Cast Bar",
+    health   = "Health Bar",
     resource = "Primary Resource",
-    class   = "Class Resource",
+    class    = "Class Resource",
+    bottom   = "Bottom Bar",
   }
 
   for index, key in ipairs(db.profile.barOrder) do

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -1092,14 +1092,6 @@ function ClassHUD:BuildFramesForSpec()
   self.db.profile.utilityPlacement[class][specID] = self.db.profile.utilityPlacement[class][specID] or {}
 
   local placements = self.db.profile.utilityPlacement[class][specID]
-  local order = self.db.profile.barOrder or {}
-  if order[1] ~= "TOP" then
-    self.db.profile.topBar.grow = "DOWN"
-  else
-    self.db.profile.topBar.grow = "UP"
-  end
-
-
   local topFrames, bottomFrames = {}, {}
   local sideFrames = { LEFT = {}, RIGHT = {} }
 
@@ -1142,22 +1134,7 @@ function ClassHUD:BuildFramesForSpec()
     end
   end
 
-  -- Auto-grow for Top-bar basert på plassering
-  do
-    local order = self.db.profile.barOrder or {}
-    local topIndex
-    for i, key in ipairs(order) do
-      if key == "TOP" then
-        topIndex = i
-        break
-      end
-    end
-    if topIndex and topIndex > 1 then
-      self.db.profile.topBar.grow = "DOWN"
-    else
-      self.db.profile.topBar.grow = "UP"
-    end
-  end
+  -- Auto-grow for Top-bar remains user configurable via options
 
 
   LayoutTopBar(topFrames)


### PR DESCRIPTION
## Summary
- replace the bars module with a profile-driven implementation that stores bars in `self.bars`, supports dynamic ordering, and applies textures/fonts from the database
- sanitize bar-related profile data, rename defaults to use `class` heights/colors, and expose new layout controls in the options UI
- rework the class resource module and dependent code to consume the new bar container and remove legacy bar-order assumptions

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfbbc55a288321ba962cd6d61af22b