### PR TITLE
Refine layout reuse and talent-based visibility

### DIFF
--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -1173,6 +1173,7 @@ for _, ev in pairs({
   -- World/spec
   "PLAYER_ENTERING_WORLD",
   "PLAYER_SPECIALIZATION_CHANGED",
+  "PLAYER_TALENT_UPDATE",
 
   -- Health
   "UNIT_HEALTH", "UNIT_MAXHEALTH",
@@ -1214,6 +1215,7 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
     local snapshotUpdated = ClassHUD:UpdateCDMSnapshot()
     if ClassHUD.BuildFramesForSpec then ClassHUD:BuildFramesForSpec() end
     if snapshotUpdated or ClassHUD._opts then ClassHUD:RefreshRegisteredOptions() end
+    if ClassHUD.RefreshSpellLoadoutVisibility then ClassHUD:RefreshSpellLoadoutVisibility() end
     if ClassHUD.RefreshAllTotems then ClassHUD:RefreshAllTotems() end
     return
   end
@@ -1229,7 +1231,14 @@ eventFrame:SetScript("OnEvent", function(_, event, unit, ...)
     if ClassHUD.BuildFramesForSpec then ClassHUD:BuildFramesForSpec() end
     ClassHUD:RefreshRegisteredOptions()
     ClassHUD:UpdateAllFrames()
+    if ClassHUD.RefreshSpellLoadoutVisibility then ClassHUD:RefreshSpellLoadoutVisibility() end
     if ClassHUD.RefreshAllTotems then ClassHUD:RefreshAllTotems() end
+    return
+  end
+
+  if event == "PLAYER_TALENT_UPDATE" then
+    if ClassHUD.RefreshSpellLoadoutVisibility then ClassHUD:RefreshSpellLoadoutVisibility() end
+    if ClassHUD.UpdateAllSpellFrames then ClassHUD:UpdateAllSpellFrames() end
     return
   end
 

--- a/ClassHUD_Bars.lua
+++ b/ClassHUD_Bars.lua
@@ -198,8 +198,7 @@ function ClassHUD:Layout()
     f:SetParent(UI.anchor)
     f:SetWidth(w)
     f._height = f._height or 0
-    f:SetHeight(f._height)
-    f:Show()
+    f:SetHeight(math.max(f._height, 1))
     return f
   end
 
@@ -224,7 +223,13 @@ function ClassHUD:Layout()
 
     local h = (enabled and height) or 0
     container._height = h
-    container:SetHeight(math.max(h, 1))
+    if enabled and h and h > 0 then
+      container:SetHeight(h)
+      container:Show()
+    else
+      container:SetHeight(1)
+      container:Hide()
+    end
 
     if not frame then return end
 
@@ -258,7 +263,13 @@ function ClassHUD:Layout()
       local showPower = layout.show.power
       local h = (showPower and layout.height.power) or 0
       container._height = h
-      container:SetHeight(math.max(h, 1))
+      if showPower and h and h > 0 then
+        container:SetHeight(h)
+        container:Show()
+      else
+        container:SetHeight(1)
+        container:Hide()
+      end
 
       if UI.power then
         UI.power:SetParent(container)
@@ -281,7 +292,13 @@ function ClassHUD:Layout()
     local container = containers.BOTTOM
     if container then
       local h = container._height or 0
-      container:SetHeight(math.max(h, 1))
+      if h and h > 0 then
+        container:SetHeight(h)
+        container:Show()
+      else
+        container:SetHeight(1)
+        container:Hide()
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- reuse layout containers by toggling frame visibility instead of recreating frames
- add spell icon eligibility checks against known spells/talents and cache placement metadata for layout
- re-evaluate icon visibility on spec and talent events to keep container sizes accurate

## Testing
- `luac -p ClassHUD_Spells.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3db3393888321b703a887793171e9