### PR TITLE
Add top bar DoT state machine and sound alerts

### DIFF
--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -621,6 +621,7 @@ local defaults = {
         spacingY = 4,
         yOffset  = 0,
         grow     = "UP",
+        pandemicHighlight = true,
         spells   = {},
       },
       bottomBar = {
@@ -692,6 +693,9 @@ local defaults = {
     },
     spellFontSize = 12,
     buffFontSize  = 12,
+    soundAlerts   = {
+      enabled = false,
+    },
   },
 }
 


### PR DESCRIPTION
## Summary
- add default profile support for pandemic highlighting and sound alert preferences along with options UI to manage global and per-spell sound selections
- extend top bar DoT updates to gate unknown spells, drive state-based desaturation, emit optional sounds, and show a pandemic glow when remaining duration drops below 30%

## Testing
- `luac -p ClassHUD.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d420af93e88321b976ec890e695145