### PR TITLE
Refactor Cooldown Manager sync flow

### DIFF
--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -2079,6 +2079,25 @@ function ClassHUD_BuildOptions(addon)
         name = "Spells & Buffs",
         order = 4,
         args = {
+          rescanSnapshot = {
+            type = "execute",
+            name = "Rescan from Cooldown Manager",
+            order = 0,
+            width = "full",
+            desc = "Import newly available spells from Blizzard's Cooldown Manager snapshot without altering your existing layout.",
+            func = function()
+              if not (addon and addon.RescanFromCDM) then return end
+              local ok, result = pcall(addon.RescanFromCDM, addon)
+              if not ok then
+                print("|cff00ff88ClassHUD|r Rescan failed:", result)
+              elseif not result then
+                -- RescanFromCDM prints its own feedback when no changes occur
+              end
+            end,
+            disabled = function()
+              return not (addon and addon.IsCooldownViewerAvailable and addon:IsCooldownViewerAvailable())
+            end,
+          },
           -- topBar = {
           --   type = "group",
           --   name = "Top Bar Spells",


### PR DESCRIPTION
## Summary
- add a RescanFromCDM helper that refreshes the Cooldown Manager snapshot on demand and merges new spells into the database without disturbing existing layouts
- stop auto-merging Cooldown Manager snapshots on specialization or talent changes while still rebuilding frames and visibility state from the saved profile
- expose a "Rescan from Cooldown Manager" button in the Spells & Buffs options pane to let players manually import newly available spells

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4fcbc58508321a1d2bf6bbeff0f25