### PR TITLE
Refactor spell frame layout to separate known and usable checks

### DIFF
--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -872,17 +872,29 @@ local function SpellMatchesPlayer(spellID)
   return false
 end
 
-local function SpellIsKnownAndUsable(spellID)
-  if not SpellMatchesPlayer(spellID) then
+local function SpellIsKnown(spellID)
+  if not spellID then
+    return false
+  end
+
+  if C_SpellBook and C_SpellBook.IsSpellKnown then
+    local ok, known = pcall(C_SpellBook.IsSpellKnown, spellID)
+    if ok then
+      return known == true
+    end
+  end
+
+  return SpellMatchesPlayer(spellID)
+end
+
+local function SpellIsCurrentlyUsable(spellID)
+  if not spellID then
     return false, false
   end
 
   if C_Spell and C_Spell.IsSpellUsable then
     local usable, insufficient = C_Spell.IsSpellUsable(spellID)
-    if usable or insufficient then
-      return true, insufficient
-    end
-    return false, insufficient and true or false
+    return usable == true, insufficient and true or false
   end
 
   return true, false
@@ -899,7 +911,7 @@ local function FilterSpellFrames(frames)
       local spellID = frame.spellID
       local allow = false
       if spellID then
-        allow = SpellIsKnownAndUsable(spellID)
+        allow = SpellIsKnown(spellID)
       end
       frame._layoutConditionHidden = not allow
       if allow then
@@ -1792,7 +1804,7 @@ local function UpdateSpellFrame(frame)
     cache.maxCharges = nil
   end
 
-  local usable, noMana = C_Spell and C_Spell.IsSpellUsable and C_Spell.IsSpellUsable(sid)
+  local usable, noMana = SpellIsCurrentlyUsable(sid)
   local resourceLimited = false
   if usable == false and noMana then
     resourceLimited = true
@@ -2352,7 +2364,7 @@ function ClassHUD:BuildFramesForSpec()
     for index = 1, #array do
       local spellID = tonumber(array[index]) or array[index]
       if spellID and not built[spellID] and not hiddenSet[spellID] then
-        local allow = SpellIsKnownAndUsable(spellID)
+        local allow = SpellIsKnown(spellID)
         if allow then
           local frame = acquire(spellID)
           frame._customOrder = index
@@ -2395,7 +2407,7 @@ function ClassHUD:BuildFramesForSpec()
 
   for _, item in ipairs(collectSnapshot("essential")) do
     local spellID = item.spellID
-    if not built[spellID] and not hiddenSet[spellID] and SpellIsKnownAndUsable(spellID) then
+    if not built[spellID] and not hiddenSet[spellID] and SpellIsKnown(spellID) then
       local frame = acquire(spellID)
       frame._customOrder = nil
       frame._trackOnTarget = shouldTrackOnTarget(spellID)
@@ -2406,7 +2418,7 @@ function ClassHUD:BuildFramesForSpec()
 
   for _, item in ipairs(collectSnapshot("utility")) do
     local spellID = item.spellID
-    if spellID and not built[spellID] and SpellIsKnownAndUsable(spellID) then
+    if spellID and not built[spellID] and SpellIsKnown(spellID) then
       hiddenSet[spellID] = true
       built[spellID] = true
     end
@@ -2414,7 +2426,7 @@ function ClassHUD:BuildFramesForSpec()
 
   for _, item in ipairs(collectSnapshot("bar")) do
     local spellID = item.spellID
-    if not built[spellID] and not hiddenSet[spellID] and SpellIsKnownAndUsable(spellID) then
+    if not built[spellID] and not hiddenSet[spellID] and SpellIsKnown(spellID) then
       local frame = acquire(spellID)
       frame._customOrder = nil
       frame._trackOnTarget = false


### PR DESCRIPTION
## Summary
- add new helpers to split spell known and usability checks
- build spell frames using the new C_SpellBook.IsSpellKnown-based helper so frames persist even when unusable
- keep runtime desaturation driven by usability while leaving frames intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d509c61e3883219735da81bec7381d