### PR TITLE
Resolve spell overrides by using active IDs

### DIFF
--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -72,6 +72,13 @@ function ClassHUD:GetActiveSpellID(spellID)
     end
   end
 
+  if C_Spell and C_Spell.GetOverrideSpell then
+    local ok, overrideID = pcall(C_Spell.GetOverrideSpell, numericID)
+    if ok and overrideID and overrideID > 0 and overrideID ~= numericID then
+      numericID = overrideID
+    end
+  end
+
   return numericID
 end
 

--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -483,9 +483,9 @@ function ClassHUD:EvaluateBuffLinks(frame, spellID)
       end
     end
     local units = isHarmful and BUFF_LINK_HARMFUL_UNITS or BUFF_LINK_HELPFUL_UNITS
-    local aura = self:GetAuraForSpell(buffID, units)
+    local aura = self:GetAuraForSpell(normalizedBuffID, units)
     if not aura and isHarmful then
-      aura = self:FindAuraByName(buffID, BUFF_LINK_HARMFUL_UNITS)
+      aura = self:FindAuraByName(normalizedBuffID, BUFF_LINK_HARMFUL_UNITS)
     end
 
     if aura then

--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -82,6 +82,45 @@ function ClassHUD:GetActiveSpellID(spellID)
   return numericID
 end
 
+---@param baseID number|nil
+---@return number|nil
+function ClassHUD:GetPermanentOverrideID(baseID)
+  local resolvedBase = tonumber(baseID)
+  if not resolvedBase or resolvedBase <= 0 then
+    return nil
+  end
+
+  if not FindSpellOverrideByID then
+    return nil
+  end
+
+  local ok, overrideID = pcall(FindSpellOverrideByID, resolvedBase)
+  if ok and overrideID and overrideID > 0 and overrideID ~= resolvedBase then
+    return overrideID
+  end
+
+  return nil
+end
+
+---@param baseID number|nil
+---@return boolean
+function ClassHUD:HasTemporaryOverride(baseID)
+  local resolvedBase = tonumber(baseID)
+  if not resolvedBase or resolvedBase <= 0 then
+    return false
+  end
+
+  local permanent = self:GetPermanentOverrideID(resolvedBase)
+  if C_Spell and C_Spell.GetOverrideSpell then
+    local ok, overrideID = pcall(C_Spell.GetOverrideSpell, resolvedBase)
+    if ok and overrideID and overrideID > 0 and overrideID ~= resolvedBase and overrideID ~= permanent then
+      return true
+    end
+  end
+
+  return false
+end
+
 local function FormatLogValue(value)
   if value == nil or value == "" then
     return "-"

--- a/ClassHUD.lua
+++ b/ClassHUD.lua
@@ -460,7 +460,6 @@ function ClassHUD:EvaluateBuffLinks(frame, spellID)
       frame._linkedBuffActive = false
       frame._linkedBuffCount = nil
       RestoreBuffLinkCount(frame)
-      ActionButton_HideOverlayGlow(frame)
       frame._linkedBuffRestoreText = cache.countText
       frame._linkedBuffRestoreShown = cache.countShown
     end
@@ -513,11 +512,8 @@ function ClassHUD:EvaluateBuffLinks(frame, spellID)
   frame._linkedBuffActive = anyActive
   frame._linkedBuffCount = highestCount
 
-  if anyActive then
-    ActionButton_ShowOverlayGlow(frame)
-  else
+  if not anyActive then
     RestoreBuffLinkCount(frame)
-    ActionButton_HideOverlayGlow(frame)
   end
 
   if anyActive and highestCount and highestCount > 0 then

--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -8,15 +8,16 @@ local ACR = LibStub("AceConfigRegistry-3.0", true)
 local LSM = LibStub("LibSharedMedia-3.0", true)
 
 local function GetSpellInfoSafe(spellID)
+  local normalizedSpellID = (ClassHUD and ClassHUD.GetActiveSpellID and ClassHUD:GetActiveSpellID(spellID)) or spellID
   if C_Spell and C_Spell.GetSpellInfo then
-    local info = C_Spell.GetSpellInfo(spellID)
+    local info = C_Spell.GetSpellInfo(normalizedSpellID)
     if info then
       return info
     end
   end
 
   if type(GetSpellInfo) == "function" then
-    local name, _, icon = GetSpellInfo(spellID)
+    local name, _, icon = GetSpellInfo(normalizedSpellID)
     if name or icon then
       return { name = name, iconID = icon }
     end

--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -1581,6 +1581,12 @@ local function BuildBuffLinkArgs(addon, container)
       get = function() return "" end,
       set = function(_, value)
         local newID = tonumber(value)
+        if FindBaseSpellByID and newID then
+          local baseID = FindBaseSpellByID(newID)
+          if baseID and baseID ~= 0 then
+            newID = baseID
+          end
+        end
         if newID then
           EnsureBuffLinkConfig(links, buffID, newID)
           addon:BuildFramesForSpec()
@@ -1819,6 +1825,12 @@ function ClassHUD_BuildOptions(addon)
         set = function(_, value)
           local spellID = tonumber(value)
           if not spellID then return end
+          if FindBaseSpellByID then
+            local baseID = FindBaseSpellByID(spellID)
+            if baseID and baseID ~= 0 then
+              spellID = baseID
+            end
+          end
           local class, specID = addon:GetPlayerClassSpec()
           local lists = EnsurePlacementLists(addon, class, specID)
           SetSpellPlacement(addon, class, specID, spellID, "TOP", #lists.TOP + 1)
@@ -1854,15 +1866,21 @@ function ClassHUD_BuildOptions(addon)
       get = function()
         return ""
       end,
-      set = function(_, value)
-        local spellID = tonumber(value)
-        if not spellID then return end
-        local class, specID = addon:GetPlayerClassSpec()
-        local lists = EnsurePlacementLists(addon, class, specID)
-        SetSpellPlacement(addon, class, specID, spellID, "HIDDEN", #lists.HIDDEN + 1)
-        addon:BuildFramesForSpec()
-        RefreshSpellEditors()
-        NotifyOptionsChanged()
+        set = function(_, value)
+          local spellID = tonumber(value)
+          if not spellID then return end
+          if FindBaseSpellByID then
+            local baseID = FindBaseSpellByID(spellID)
+            if baseID and baseID ~= 0 then
+              spellID = baseID
+            end
+          end
+          local class, specID = addon:GetPlayerClassSpec()
+          local lists = EnsurePlacementLists(addon, class, specID)
+          SetSpellPlacement(addon, class, specID, spellID, "HIDDEN", #lists.HIDDEN + 1)
+          addon:BuildFramesForSpec()
+          RefreshSpellEditors()
+          NotifyOptionsChanged()
       end,
     },
     empty = {
@@ -3058,6 +3076,12 @@ function ClassHUD:GetUtilityOptions()
         set = function(_, value)
           local spellID = tonumber(value)
           if not spellID then return end
+          if FindBaseSpellByID then
+            local baseID = FindBaseSpellByID(spellID)
+            if baseID and baseID ~= 0 then
+              spellID = baseID
+            end
+          end
           local class, specID = self:GetPlayerClassSpec()
           local lists = EnsurePlacementLists(self, class, specID)
           SetSpellPlacement(self, class, specID, spellID, "HIDDEN", #lists.HIDDEN + 1)

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -1597,6 +1597,29 @@ local function UpdateSpellFrame(frame)
   if not baseSpellID then return end
 
   local sid = ClassHUD:GetActiveSpellID(baseSpellID) or baseSpellID
+  local resolvedBaseID = baseSpellID
+  if FindBaseSpellByID then
+    local ok, baseID = pcall(FindBaseSpellByID, baseSpellID)
+    if ok and baseID and baseID ~= 0 then
+      resolvedBaseID = baseID
+    end
+  end
+
+  local hasOverride = sid and resolvedBaseID and (sid ~= resolvedBaseID)
+  if hasOverride then
+    if not frame._overrideGlowActive then
+      if ActionButton_ShowOverlayGlow then
+        ActionButton_ShowOverlayGlow(frame)
+      end
+      frame._overrideGlowActive = true
+    end
+  elseif frame._overrideGlowActive then
+    if ActionButton_HideOverlayGlow then
+      ActionButton_HideOverlayGlow(frame)
+    end
+    frame._overrideGlowActive = nil
+  end
+
   SetFrameActiveSpell(frame, sid)
 
   local cache = frame._last

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -1604,19 +1604,18 @@ end
 -- UpdateSpellFrame
 -- ==================================================
 local function UpdateSpellFrame(frame)
-  local baseSpellID = frame.spellID
-  if not baseSpellID then return end
+  local originalSpellID = frame.spellID
+  if not originalSpellID then return end
 
-  local sid = ClassHUD:GetActiveSpellID(baseSpellID) or baseSpellID
-  local resolvedBaseID = baseSpellID
+  local baseSpellID = originalSpellID
   if FindBaseSpellByID then
-    local ok, baseID = pcall(FindBaseSpellByID, baseSpellID)
+    local ok, baseID = pcall(FindBaseSpellByID, originalSpellID)
     if ok and baseID and baseID ~= 0 then
-      resolvedBaseID = baseID
+      baseSpellID = baseID
     end
   end
 
-  local overrideActive = sid and resolvedBaseID and (sid ~= resolvedBaseID)
+  local sid = ClassHUD:GetActiveSpellID(baseSpellID) or baseSpellID
   frame._overrideGlowActive = nil
 
   SetFrameActiveSpell(frame, sid)
@@ -2221,7 +2220,7 @@ local function UpdateSpellFrame(frame)
   if frame._totemGlowActive then
     shouldGlow = true
   end
-  if overrideActive then
+  if ClassHUD.HasTemporaryOverride and ClassHUD:HasTemporaryOverride(baseSpellID) then
     shouldGlow = true
   end
 

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -1192,12 +1192,21 @@ local function PopulateBuffIconFrame(frame, buffID, aura, entry)
   end
 
   local normalizedBuffID = ClassHUD:GetActiveSpellID(buffID) or buffID
-  local iconID = entry and entry.iconID
-  if not iconID then
-    local info = C_Spell.GetSpellInfo(normalizedBuffID)
-    iconID = info and info.iconID
+  local snapshotIconID = entry and entry.iconID
+  local info = C_Spell.GetSpellInfo(normalizedBuffID)
+  local activeIconID = (C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(normalizedBuffID)) or (info and info.iconID)
+  frame.icon:SetTexture(activeIconID or snapshotIconID or 134400)
+
+  local tooltipName = entry and entry.name or (info and info.name) or (C_Spell.GetSpellName and C_Spell.GetSpellName(normalizedBuffID))
+  local tooltipDesc = entry and entry.desc
+  if not tooltipDesc and C_Spell.GetSpellDescription then
+    tooltipDesc = C_Spell.GetSpellDescription(normalizedBuffID)
   end
-  frame.icon:SetTexture(iconID or C_Spell.GetSpellTexture(normalizedBuffID) or 134400)
+
+  frame.tooltipSpellID = normalizedBuffID
+  frame._tooltipSpellID = normalizedBuffID
+  frame.tooltipTitle = tooltipName
+  frame.tooltipText = tooltipDesc
 
   if aura and aura.expirationTime and aura.duration and aura.duration > 0 then
     frame.cooldown:SetCooldown(aura.expirationTime - aura.duration, aura.duration, aura.modRate or 1)
@@ -1305,16 +1314,25 @@ local function UpdateTrackedIconFrame(frame)
 
   if aura then
     local normalizedBuffID = ClassHUD:GetActiveSpellID(buffID) or buffID
-    local iconID = entry and entry.iconID
-    if not iconID then
-      local info = C_Spell.GetSpellInfo(normalizedBuffID)
-      iconID = info and info.iconID
-    end
-    iconID = iconID or C_Spell.GetSpellTexture(normalizedBuffID) or 134400
+    local snapshotIconID = entry and entry.iconID
+    local info = C_Spell.GetSpellInfo(normalizedBuffID)
+    local activeIconID = (C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(normalizedBuffID)) or (info and info.iconID)
+    local iconID = activeIconID or snapshotIconID or 134400
     if cache.iconID ~= iconID then
       frame.icon:SetTexture(iconID)
       cache.iconID = iconID
     end
+
+    local tooltipName = entry and entry.name or (info and info.name) or (C_Spell.GetSpellName and C_Spell.GetSpellName(normalizedBuffID))
+    local tooltipDesc = entry and entry.desc
+    if not tooltipDesc and C_Spell.GetSpellDescription then
+      tooltipDesc = C_Spell.GetSpellDescription(normalizedBuffID)
+    end
+
+    frame.tooltipSpellID = normalizedBuffID
+    frame._tooltipSpellID = normalizedBuffID
+    frame.tooltipTitle = tooltipName
+    frame.tooltipText = tooltipDesc
 
     if aura.expirationTime and aura.duration and aura.duration > 0 then
       frame.cooldown:SetCooldown(aura.expirationTime - aura.duration, aura.duration, aura.modRate or 1)
@@ -1381,6 +1399,10 @@ local function UpdateTrackedIconFrame(frame)
   ClassHUD:ApplyCooldownText(frame, ShouldShowCooldownNumbers(), nil)
   frame:Hide()
   frame._layoutActive = false
+  frame.tooltipSpellID = nil
+  frame._tooltipSpellID = nil
+  frame.tooltipTitle = nil
+  frame.tooltipText = nil
   return false
 end
 
@@ -1689,17 +1711,26 @@ local function UpdateSpellFrame(frame)
 
   RegisterFrameAuraWatchers(frame, watcherCandidates, watcherUnits)
 
-  local iconID = entry and entry.iconID
-  if not iconID then
-    local info = C_Spell.GetSpellInfo(sid)
-    iconID = info and info.iconID
-  end
-  iconID = iconID or 134400
+  local snapshotIconID = entry and entry.iconID
+  local info = C_Spell.GetSpellInfo(sid)
+  local activeIconID = (C_Spell.GetSpellTexture and C_Spell.GetSpellTexture(sid)) or (info and info.iconID)
+  local iconID = activeIconID or snapshotIconID or 134400
   local baseIconID = iconID
   if cache.iconID ~= iconID then
     frame.icon:SetTexture(iconID)
     cache.iconID = iconID
   end
+
+  local tooltipName = entry and entry.name or (info and info.name) or (C_Spell.GetSpellName and C_Spell.GetSpellName(sid))
+  local tooltipDesc = entry and entry.desc
+  if not tooltipDesc and C_Spell.GetSpellDescription then
+    tooltipDesc = C_Spell.GetSpellDescription(sid)
+  end
+
+  frame.tooltipSpellID = sid
+  frame._tooltipSpellID = sid
+  frame.tooltipTitle = tooltipName
+  frame.tooltipText = tooltipDesc
 
   local aura, auraSpellID, auraUnit = nil, nil, nil
   if auraCandidates then

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -556,7 +556,13 @@ local function UpdateGlow(frame, aura, sid, data)
   local allowExtraGlowLogic = true
 
   local normalizedSpellID = ClassHUD:GetActiveSpellID(sid) or sid
-  local isHarmfulSpell = C_Spell and C_Spell.IsSpellHarmful and C_Spell.IsSpellHarmful(normalizedSpellID)
+  local isHarmfulSpell = false
+  if C_Spell and C_Spell.IsSpellHarmful then
+    local ok, result = pcall(C_Spell.IsSpellHarmful, normalizedSpellID)
+    if ok and result then
+      isHarmfulSpell = true
+    end
+  end
 
   if isHarmfulSpell then
     allowExtraGlowLogic = false
@@ -2364,9 +2370,10 @@ function ClassHUD:RebuildTrackedBuffFrames()
     ClassHUD:NormalizeBuffLinkTable(links)
 
     for buffID in pairs(links) do
-      local aura = C_UnitAuras.GetPlayerAuraBySpellID and C_UnitAuras.GetPlayerAuraBySpellID(buffID)
+      local normalizedBuffID = self:GetActiveSpellID(buffID) or buffID
+      local aura = C_UnitAuras.GetPlayerAuraBySpellID and C_UnitAuras.GetPlayerAuraBySpellID(normalizedBuffID)
       if not aura and UnitExists("pet") and C_UnitAuras and C_UnitAuras.GetAuraDataBySpellID then
-        aura = C_UnitAuras.GetAuraDataBySpellID("pet", buffID)
+        aura = C_UnitAuras.GetAuraDataBySpellID("pet", normalizedBuffID)
       end
     end
   end

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -1483,7 +1483,8 @@ function ClassHUD:BuildTrackedBuffFrames()
           order = math.min(order, entry.categories.buff.order)
         end
       end
-      local name = entry and entry.name or C_Spell.GetSpellName(buffID) or ("Spell " .. buffID)
+      local activeBuffID = self:GetActiveSpellID(buffID) or buffID
+      local name = entry and entry.name or C_Spell.GetSpellName(activeBuffID) or ("Spell " .. activeBuffID)
       local manualIndex = orderLookup[buffID]
       if not manualIndex then
         orderArray[#orderArray + 1] = buffID

--- a/ClassHUD_Spells.lua
+++ b/ClassHUD_Spells.lua
@@ -953,8 +953,31 @@ local function SpellIsKnown(spellID)
 
   local normalizedSpellID = ClassHUD:GetActiveSpellID(spellID) or spellID
 
-  if C_SpellBook and C_SpellBook.IsSpellKnown then
-    local ok, known = pcall(C_SpellBook.IsSpellKnown, normalizedSpellID)
+  if C_SpellBook then
+    if C_SpellBook.IsSpellInSpellBook then
+      local ok, inBook = pcall(C_SpellBook.IsSpellInSpellBook, normalizedSpellID)
+      if ok and inBook then
+        return true
+      end
+    end
+
+    if C_SpellBook.IsSpellKnownOrOverridesKnown then
+      local ok, known = pcall(C_SpellBook.IsSpellKnownOrOverridesKnown, normalizedSpellID)
+      if ok then
+        return known == true
+      end
+    end
+
+    if C_SpellBook.IsSpellKnown then
+      local ok, known = pcall(C_SpellBook.IsSpellKnown, normalizedSpellID)
+      if ok then
+        return known == true
+      end
+    end
+  end
+
+  if IsSpellKnownOrOverridesKnown then
+    local ok, known = pcall(IsSpellKnownOrOverridesKnown, normalizedSpellID)
     if ok then
       return known == true
     end

--- a/ClassHUD_Tracking.lua
+++ b/ClassHUD_Tracking.lua
@@ -25,7 +25,6 @@ ClassHUD.WILD_IMP_DISPLAY_SPELL_ID = WILD_IMP_DISPLAY_SPELL_ID
 local ShouldShowCooldownNumbers = ClassHUD.ShouldShowCooldownNumbers
 local PopulateBuffIconFrame = ClassHUD.PopulateBuffIconFrame
 local CreateBuffFrame = ClassHUD.CreateBuffFrame
-local SetFrameGlow = ClassHUD.SetFrameGlow
 
 local function Contains(list, value)
   if type(list) ~= "table" then return false end
@@ -1181,7 +1180,6 @@ function ClassHUD:ApplyTotemOverlay(state)
     cooldown:SetCooldown(startTime, duration)
     cooldown:Show()
     frame._totemGlowActive = nil
-    SetFrameGlow(frame, false)
   else
     if frame.totemCooldown then
       CooldownFrame_Clear(frame.totemCooldown)
@@ -1190,16 +1188,21 @@ function ClassHUD:ApplyTotemOverlay(state)
 
     if style == "GLOW" or not duration or duration <= 0 then
       frame._totemGlowActive = true
-      SetFrameGlow(frame, true)
     else
       frame._totemGlowActive = nil
-      SetFrameGlow(frame, false)
     end
   end
 
   frame._totemActive = true
   frame._totemSlot = state.slot
   frame._activeTotemState = state
+
+  if self.UpdateCooldown then
+    local updateSpellID = state.spellID or frame.spellID
+    if updateSpellID then
+      self:UpdateCooldown(updateSpellID)
+    end
+  end
 
   if self:IsTotemDurationTextEnabled() and self:HasTotemDuration(state) then
     local now = GetTime()
@@ -1228,10 +1231,7 @@ function ClassHUD:ClearTotemOverlay(state)
     frame.totemCooldown:Hide()
   end
 
-  if frame._totemGlowActive then
-    frame._totemGlowActive = nil
-    SetFrameGlow(frame, false)
-  end
+  frame._totemGlowActive = nil
 
   frame._totemActive = nil
   frame._totemSlot = nil


### PR DESCRIPTION
## Summary
- add ClassHUD:GetActiveSpellID and refresh active spell mappings on spec or talent changes
- normalize cooldown, aura, and range logic to resolve frames against active spell IDs
- update tracking, options, and shared utilities to query spell data via the resolved IDs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d56d69e4a48321ab815f33ba74378f