### PR TITLE
Set up release workflow for tagged versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,56 +3,51 @@ name: Release Addon
 on:
   push:
     tags:
-      - "v*.*.*" # e.g. v1.0.0
+      - "v*.*.*"
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      ADDON_NAME: ClassHUD
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Determine version information
+        id: version
+        run: |
+          TAG_NAME="${GITHUB_REF_NAME}"
+          VERSION="${TAG_NAME#v}"
+          ZIP_NAME="${ADDON_NAME}-${TAG_NAME}.zip"
+
+          echo "tag_name=${TAG_NAME}" >> "$GITHUB_OUTPUT"
+          echo "addon_version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "zip_name=${ZIP_NAME}" >> "$GITHUB_OUTPUT"
+
       - name: Inject version into TOC
         run: |
-          VERSION=${GITHUB_REF_NAME}   # GITHUB_REF_NAME = f.eks. v1.0.0
-          VERSION=${VERSION#v}         # fjern leading "v"
-          echo "Using version: $VERSION"
-          sed -i "s/@project-version@/$VERSION/" ClassHUD.toc
-
-      - name: Set up addon metadata
-        run: |
-          ADDON_NAME="ClassHUD"
-          echo "ADDON_NAME=$ADDON_NAME" >> $GITHUB_ENV
+          sed -i "s/@project-version@/${{ steps.version.outputs.addon_version }}/" ClassHUD.toc
 
       - name: Package addon
         run: |
-          mkdir -p build/${{ env.ADDON_NAME }}
-          # Copy all addon files except git/github stuff
-          rsync -av --exclude='.git*' --exclude='.github' ./ build/${{ env.ADDON_NAME }}/
+          mkdir -p build/${ADDON_NAME}
+          rsync -a \
+            --exclude='.git/' \
+            --exclude='.github/' \
+            --exclude='build/' \
+            ./ build/${ADDON_NAME}/
           cd build
-          zip -r ../${{ env.ADDON_NAME }}.zip ${{ env.ADDON_NAME }}
+          zip -r "../${{ steps.version.outputs.zip_name }}" "${ADDON_NAME}"
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.ADDON_NAME }}-zip
-          path: ./${{ env.ADDON_NAME }}.zip
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ClassHUD-zip
-          path: .
-
-      - name: Create GitHub Release
+      - name: Create or update GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          files: ClassHUD.zip
+          tag_name: ${{ steps.version.outputs.tag_name }}
+          files: ${{ steps.version.outputs.zip_name }}
+          generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- rebuild the release workflow to trigger on semver tags and package the addon with the expected folder layout
- name the generated archive from the tag (e.g., ClassHUD-v1.3.0.zip) and inject the version into the TOC file
- publish the archive to the tag's release using softprops/action-gh-release with the required permissions

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d65977931083219715a119f8b322b4