### PR TITLE
Fix aura usability coloring and allow removing tracked buffs

### DIFF
--- a/ClassHUD_Options.lua
+++ b/ClassHUD_Options.lua
@@ -430,19 +430,6 @@ local function SetTrackedBuffOrder(addon, class, specID, buffID, position)
   table.insert(orderList, target, buffID)
 end
 
-local function RemoveTrackedBuff(addon, class, specID, buffID)
-  local tracked, links = EnsureBuffTracking(addon, class, specID)
-  local orderList = EnsureTrackedBuffOrder(addon, class, specID)
-  tracked[buffID] = nil
-  links[buffID] = nil
-  for index = #orderList, 1, -1 do
-    local value = tonumber(orderList[index]) or orderList[index]
-    if value == buffID then
-      table.remove(orderList, index)
-    end
-  end
-end
-
 local function EnsurePlacementLists(addon, class, specID)
   addon.db.profile.layout = addon.db.profile.layout or {}
   local layout = addon.db.profile.layout
@@ -1409,8 +1396,7 @@ local function PopulateTrackedBuffGroups(addon, container, state, refreshFn)
           confirm = true,
           order = 99,
           func = function()
-            RemoveTrackedBuff(addon, class, specID, buffID)
-            addon:BuildTrackedBuffFrames()
+            addon:RemoveTrackedBuff(buffID, class, specID)
             if type(refreshFn) == "function" then refreshFn() end
             -- NotifyOptionsChanged()
           end,

--- a/ClassHUD_Utils.lua
+++ b/ClassHUD_Utils.lua
@@ -7,8 +7,8 @@ local ClassHUD = _G.ClassHUD or LibStub("AceAddon-3.0"):GetAddon("ClassHUD")
 ClassHUD._lastSpecID = ClassHUD._lastSpecID or 0
 ClassHUD._snapshotStore = ClassHUD._snapshotStore or {}
 
-local C_Spell, C_UnitAuras, GetTime, floor, tostring, ipairs, pairs = C_Spell, C_UnitAuras, GetTime, floor, tostring,
-    ipairs, pairs
+local C_Spell, C_UnitAuras, GetTime, floor, tostring, ipairs, pairs, IsUsableSpell = C_Spell, C_UnitAuras, GetTime, floor,
+    tostring, ipairs, pairs, IsUsableSpell
 
 local DEFAULT_TRACKED_BAR_COLOR = { r = 0.25, g = 0.65, b = 1.00, a = 1 }
 local SOUND_NONE_KEY = "None"
@@ -180,6 +180,29 @@ function ClassHUD:PlayAlertSound(soundKey)
   end
 
   return false
+end
+
+---Checks whether a spell is currently usable, resolving override spell IDs first.
+---@param spellID number|string|nil
+---@return boolean usable, boolean noMana
+function ClassHUD:IsSpellUsableResolved(spellID)
+  if spellID == nil then
+    return false, false
+  end
+
+  local resolved = self:GetActiveSpellID(spellID) or tonumber(spellID)
+  if not resolved then
+    return false, false
+  end
+
+  if IsUsableSpell then
+    local ok, usable, noMana = pcall(IsUsableSpell, resolved)
+    if ok then
+      return usable == true, noMana and true or false
+    end
+  end
+
+  return true, false
 end
 
 local function NormalizeTrackedConfigTable(config)


### PR DESCRIPTION
## Summary
- add an override-aware `IsSpellUsableResolved` helper and use it to drive spell usability checks
- keep tracked-on-target spells colored when their aura is active while still honoring cooldown and range overlays
- add a `RemoveTrackedBuff` API that cleans up saved data and hook the options delete button to use it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6db0c43948321bd1f6fa69e220ab4